### PR TITLE
Show missing count on a separate row

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "tableone-ci"
+name = "tableone"
 version = "0.8.0"
 authors = [
   { name="Tom Pollard", email="tpollard@mit.edu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "tableone"
+name = "tableone-ci"
 version = "0.8.0"
 authors = [
   { name="Tom Pollard", email="tpollard@mit.edu" },
@@ -39,4 +39,4 @@ reportMissingImports = true
 [project.urls]
 homepage = "https://github.com/tompollard/tableone/"
 documentation = "https://tableone.readthedocs.io/"
-repository = "https://github.com/tompollard/tableone/"
+repository = "https://github.com/cipherome/tableone-ci/"

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -240,7 +240,7 @@ class TableOne:
         normal_test: bool = False,
         tukey_test: bool = False,
         pval_threshold: Optional[float] = None,
-        missing_value_on_separate_row: bool = True,
+        missing_value_on_separate_row: bool = False,
     ) -> None:
         # labels is now rename
         if labels is not None and rename is not None:

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -1414,7 +1414,7 @@ class TableOne:
             table = self.cat_table
 
         # ensure column headers are strings before reindexing
-        # table = table.reset_index().set_index(["variable", "value"])  # type: ignore
+        table = table.reset_index().set_index(["variable", "value"])  # type: ignore
         table.columns = table.columns.values.astype(str)
 
         # sort the table rows

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -1519,7 +1519,7 @@ class TableOne:
                     # apply order
                     all_var = table.loc[k].index.unique(level="value")
                     new_idx = [(k, " ")] if self._isnull and self._missing_value_on_separate_row else []
-                    new_idx = +[(k, "{}".format(v)) for v in self._order[k]]
+                    new_idx += [(k, "{}".format(v)) for v in self._order[k]]
                     new_idx += [(k, "{}".format(v)) for v in all_var if v not in self._order[k]]
 
                 # restructure to match the original idx

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -15,7 +15,7 @@ from tabulate import tabulate
 from tableone.modality import hartigan_diptest
 
 # display deprecation warnings
-warnings.simplefilter('always', DeprecationWarning)
+warnings.simplefilter("always", DeprecationWarning)
 
 
 def load_dataset(name: str) -> pd.DataFrame:
@@ -34,8 +34,7 @@ def load_dataset(name: str) -> pd.DataFrame:
     df : :class:`pandas.DataFrame`
         Tabular data.
     """
-    path = ("https://raw.githubusercontent.com/"
-            "tompollard/tableone/master/datasets/{}.csv")
+    path = "https://raw.githubusercontent.com/" "tompollard/tableone/master/datasets/{}.csv"
     full_path = path.format(name)
 
     df = pd.read_csv(full_path)
@@ -47,9 +46,11 @@ def docstring_copier(*sub):
     """
     Wrap the TableOne docstring (not ideal :/)
     """
+
     def dec(obj):
         obj.__doc__ = obj.__doc__.format(*sub)
         return obj
+
     return dec
 
 
@@ -57,6 +58,7 @@ class InputError(Exception):
     """
     Exception raised for errors in the input.
     """
+
     pass
 
 
@@ -200,57 +202,69 @@ class TableOne:
 
     ...
     """
-    def __init__(self, data: pd.DataFrame,
-                 columns: Optional[list] = None,
-                 categorical: Optional[list] = None,
-                 groupby: Optional[str] = None,
-                 nonnormal: Optional[list] = None,
-                 min_max: Optional[list] = None, pval: Optional[bool] = False,
-                 pval_adjust: Optional[str] = None, htest_name: bool = False,
-                 pval_test_name: bool = False, htest: Optional[dict] = None,
-                 isnull: Optional[bool] = None, missing: bool = True,
-                 ddof: int = 1, labels: Optional[dict] = None,
-                 rename: Optional[dict] = None, sort: Union[bool, str] = False,
-                 limit: Union[int, dict, None] = None,
-                 order: Optional[dict] = None, remarks: bool = False,
-                 label_suffix: bool = True, decimals: Union[int, dict] = 1,
-                 smd: bool = False, overall: bool = True,
-                 row_percent: bool = False, display_all: bool = False,
-                 dip_test: bool = False, normal_test: bool = False,
-                 tukey_test: bool = False,
-                 pval_threshold: Optional[float] = None) -> None:
 
+    def __init__(
+        self,
+        data: pd.DataFrame,
+        columns: Optional[list] = None,
+        categorical: Optional[list] = None,
+        groupby: Optional[str] = None,
+        nonnormal: Optional[list] = None,
+        min_max: Optional[list] = None,
+        pval: Optional[bool] = False,
+        pval_adjust: Optional[str] = None,
+        htest_name: bool = False,
+        pval_test_name: bool = False,
+        htest: Optional[dict] = None,
+        isnull: Optional[bool] = None,
+        missing: bool = True,
+        ddof: int = 1,
+        labels: Optional[dict] = None,
+        rename: Optional[dict] = None,
+        sort: Union[bool, str] = False,
+        limit: Union[int, dict, None] = None,
+        order: Optional[dict] = None,
+        remarks: bool = False,
+        label_suffix: bool = True,
+        decimals: Union[int, dict] = 1,
+        smd: bool = False,
+        overall: bool = True,
+        row_percent: bool = False,
+        display_all: bool = False,
+        dip_test: bool = False,
+        normal_test: bool = False,
+        tukey_test: bool = False,
+        pval_threshold: Optional[float] = None,
+    ) -> None:
         # labels is now rename
         if labels is not None and rename is not None:
             raise TypeError("TableOne received both labels and rename.")
         elif labels is not None:
-            warnings.warn("The labels argument is deprecated; use "
-                          "rename instead.", DeprecationWarning)
+            warnings.warn("The labels argument is deprecated; use " "rename instead.", DeprecationWarning)
             self._alt_labels = labels
         else:
             self._alt_labels = rename
 
         # isnull is now missing
         if isnull is not None:
-            warnings.warn("The isnull argument is deprecated; use "
-                          "missing instead.", DeprecationWarning)
+            warnings.warn("The isnull argument is deprecated; use " "missing instead.", DeprecationWarning)
             self._isnull = isnull
         else:
             self._isnull = missing
 
         # pval_test_name is now htest_name
         if pval_test_name:
-            warnings.warn("The pval_test_name argument is deprecated; use "
-                          "htest_name instead.", DeprecationWarning)
+            warnings.warn("The pval_test_name argument is deprecated; use " "htest_name instead.", DeprecationWarning)
             self._pval_test_name = pval_test_name
         else:
             self._pval_test_name = htest_name
 
         # remarks are now specified by individual test names
         if remarks:
-            warnings.warn("The remarks argument is deprecated; specify tests "
-                          "by name instead (e.g. diptest = True)",
-                          DeprecationWarning)
+            warnings.warn(
+                "The remarks argument is deprecated; specify tests " "by name instead (e.g. diptest = True)",
+                DeprecationWarning,
+            )
             self._dip_test = remarks
             self._normal_test = remarks
             self._tukey_test = remarks
@@ -261,7 +275,7 @@ class TableOne:
 
         # groupby should be a string
         if not groupby:
-            groupby = ''
+            groupby = ""
         elif groupby and type(groupby) == list:
             groupby = groupby[0]
 
@@ -282,8 +296,7 @@ class TableOne:
 
         # if the input dataframe has a non-unique index, raise error
         if not data.index.is_unique:
-            raise InputError("Input data contains duplicate values in the "
-                             "index. Reset the index and try again.")
+            raise InputError("Input data contains duplicate values in the " "index. Reset the index and try again.")
 
         # if columns are not specified, use all columns
         if not columns:
@@ -292,15 +305,22 @@ class TableOne:
         # check that the columns exist in the dataframe
         if not set(columns).issubset(data.columns):  # type: ignore
             notfound = list(set(columns) - set(data.columns))  # type: ignore
-            raise InputError("""Columns not found in
-                                dataset: {}""".format(notfound))
+            raise InputError(
+                """Columns not found in
+                                dataset: {}""".format(
+                    notfound
+                )
+            )
 
         # check for duplicate columns
-        dups = data[columns].columns[
-            data[columns].columns.duplicated()].unique()
+        dups = data[columns].columns[data[columns].columns.duplicated()].unique()
         if not dups.empty:
-            raise InputError("""Input data contains duplicate
-                                columns: {}""".format(dups))
+            raise InputError(
+                """Input data contains duplicate
+                                columns: {}""".format(
+                    dups
+                )
+            )
 
         # if categorical not specified, try to identify categorical
         if not categorical and type(categorical) != list:
@@ -310,8 +330,10 @@ class TableOne:
                 categorical = [x for x in categorical if x != groupby]
 
         if isinstance(pval_adjust, bool) and pval_adjust:
-            msg = ("pval_adjust expects a string, but a boolean was specified."
-                   " Defaulting to the 'bonferroni' correction.")
+            msg = (
+                "pval_adjust expects a string, but a boolean was specified."
+                " Defaulting to the 'bonferroni' correction."
+            )
             warnings.warn(msg)
             pval_adjust = "bonferroni"
 
@@ -320,12 +342,10 @@ class TableOne:
             order = {k: ["{}".format(v) for v in order[k]] for k in order}
 
         # if input df has ordered categorical variables, get the order.
-        order_cats = [x for x in data.select_dtypes("category")
-                      if data[x].dtype.ordered]  # type: ignore
+        order_cats = [x for x in data.select_dtypes("category") if data[x].dtype.ordered]  # type: ignore
         if any(order_cats):
             d_order_cats = {v: data[v].cat.categories for v in order_cats}
-            d_order_cats = {k: ["{}".format(v) for v in d_order_cats[k]]
-                            for k in d_order_cats}
+            d_order_cats = {k: ["{}".format(v) for v in d_order_cats[k]] for k in d_order_cats}
 
         # combine the orders. custom order takes precedence.
         if order_cats and order:
@@ -340,8 +360,7 @@ class TableOne:
             raise InputError("If pval=True then groupby must be specified.")
 
         self._columns = list(columns)  # type: ignore
-        self._continuous = [c for c in columns  # type: ignore
-                            if c not in categorical + [groupby]]
+        self._continuous = [c for c in columns if c not in categorical + [groupby]]  # type: ignore
         self._categorical = categorical
         self._nonnormal = nonnormal
         self._min_max = min_max
@@ -365,25 +384,27 @@ class TableOne:
         self._warnings = {}
 
         # output column names that cannot be contained in a groupby
-        self._reserved_columns = ['Missing', 'P-Value', 'Test',
-                                  'P-Value (adjusted)', 'SMD', 'Overall']
+        self._reserved_columns = ["Missing", "P-Value", "Test", "P-Value (adjusted)", "SMD", "Overall"]
 
         if self._groupby:
             self._groupbylvls = sorted(data.groupby(groupby).groups.keys())  # type: ignore
 
             # reorder the groupby levels if order is provided
             if self._order and self._groupby in self._order:
-                unordered = [x for x in self._groupbylvls
-                             if x not in self._order[self._groupby]]
+                unordered = [x for x in self._groupbylvls if x not in self._order[self._groupby]]
                 self._groupbylvls = self._order[self._groupby] + unordered
 
             # check that the group levels do not include reserved words
             for level in self._groupbylvls:
                 if level in self._reserved_columns:
-                    raise InputError("""Group level contains '{}', a reserved
-                                        keyword.""".format(level))
+                    raise InputError(
+                        """Group level contains '{}', a reserved
+                                        keyword.""".format(
+                            level
+                        )
+                    )
         else:
-            self._groupbylvls = ['Overall']
+            self._groupbylvls = ["Overall"]
 
         # forgive me jraffa
         if self._pval:
@@ -392,31 +413,25 @@ class TableOne:
         # correct for multiple testing
         if self._pval and self._pval_adjust:
             alpha = 0.05
-            adjusted = multitest.multipletests(self._htest_table['P-Value'],
-                                               alpha=alpha,
-                                               method=self._pval_adjust)
-            self._htest_table['P-Value (adjusted)'] = adjusted[1]
-            self._htest_table['adjust method'] = self._pval_adjust
+            adjusted = multitest.multipletests(self._htest_table["P-Value"], alpha=alpha, method=self._pval_adjust)
+            self._htest_table["P-Value (adjusted)"] = adjusted[1]
+            self._htest_table["adjust method"] = self._pval_adjust
 
         # create overall tables if required
         if self._categorical and self._groupby and overall:
-            self.cat_describe_all = self._create_cat_describe(data=data,
-                                                              groupby=None,
-                                                              groupbylvls=['Overall'])
+            self.cat_describe_all = self._create_cat_describe(data=data, groupby=None, groupbylvls=["Overall"])
 
         if self._continuous and self._groupby and overall:
-            self.cont_describe_all = self._create_cont_describe(data=data,
-                                                                groupby=None)
+            self.cont_describe_all = self._create_cont_describe(data=data, groupby=None)
 
         # create descriptive tables
         if self._categorical:
-            self.cat_describe = self._create_cat_describe(data=data,
-                                                          groupby=self._groupby,
-                                                          groupbylvls=self._groupbylvls)
+            self.cat_describe = self._create_cat_describe(
+                data=data, groupby=self._groupby, groupbylvls=self._groupbylvls
+            )
 
         if self._continuous:
-            self.cont_describe = self._create_cont_describe(data=data,
-                                                            groupby=self._groupby)
+            self.cont_describe = self._create_cont_describe(data=data, groupby=self._groupby)
 
         # compute standardized mean differences
         if self._smd:
@@ -446,32 +461,36 @@ class TableOne:
             self._set_display_options()
 
     def __str__(self) -> str:
-        return self.tableone.to_string() + self._generate_remarks('\n')
+        return self.tableone.to_string() + self._generate_remarks("\n")
 
     def __repr__(self) -> str:
-        return self.tableone.to_string() + self._generate_remarks('\n')
+        return self.tableone.to_string() + self._generate_remarks("\n")
 
     def _repr_html_(self) -> str:
-        return self.tableone._repr_html_() + self._generate_remarks('<br />')
+        return self.tableone._repr_html_() + self._generate_remarks("<br />")
 
     def _set_display_options(self):
         """
         Set pandas display options. Display all rows and columns by default.
         """
-        display_options = {'display.max_rows': None,
-                           'display.max_columns': None,
-                           'display.width': None,
-                           'display.max_colwidth': None}
+        display_options = {
+            "display.max_rows": None,
+            "display.max_columns": None,
+            "display.width": None,
+            "display.max_colwidth": None,
+        }
 
         for k in display_options:
             try:
                 pd.set_option(k, display_options[k])
             except ValueError:
                 msg = """Newer version of Pandas required to set the '{}'
-                         option.""".format(k)
+                         option.""".format(
+                    k
+                )
                 warnings.warn(msg)
 
-    def tabulate(self, headers=None, tablefmt='grid', **kwargs) -> str:
+    def tabulate(self, headers=None, tablefmt="grid", **kwargs) -> str:
         """
         Pretty-print tableone data. Wrapper for the Python 'tabulate' library.
 
@@ -499,14 +518,14 @@ class TableOne:
                 headers = df.columns
 
         df = df.reset_index()
-        df = df.set_index('level_0')
+        df = df.set_index("level_0")
         isdupe = df.index.duplicated()
-        df.index = df.index.where(~isdupe, '')
-        df = df.rename_axis(None).rename(columns={'level_1': ''})
+        df.index = df.index.where(~isdupe, "")
+        df = df.rename_axis(None).rename(columns={"level_1": ""})
 
         return tabulate(df, headers=headers, tablefmt=tablefmt, **kwargs)
 
-    def _generate_remarks(self, newline='\n') -> str:
+    def _generate_remarks(self, newline="\n") -> str:
         """
         Generate a series of remarks that the user should consider
         when interpreting the summary statistics.
@@ -515,40 +534,39 @@ class TableOne:
         if self._continuous and self._tukey_test:
             # highlight far outliers
             outlier_mask = self.cont_describe.far_outliers > 1
-            outlier_vars = list(self.cont_describe.far_outliers[outlier_mask].
-                                dropna(how='all').index)
+            outlier_vars = list(self.cont_describe.far_outliers[outlier_mask].dropna(how="all").index)
             if outlier_vars:
-                self._warnings["""Tukey test indicates far outliers
-                                  in"""] = outlier_vars
+                self._warnings[
+                    """Tukey test indicates far outliers
+                                  in"""
+                ] = outlier_vars
 
         if self._continuous and self._dip_test:
             # highlight possible multimodal distributions using hartigan's dip
             # test -1 values indicate NaN
-            modal_mask = ((self.cont_describe.hartigan_dip >= 0) &
-                          (self.cont_describe.hartigan_dip <= 0.05))
-            modal_vars = list(self.cont_describe.hartigan_dip[modal_mask].
-                              dropna(how='all').index)
+            modal_mask = (self.cont_describe.hartigan_dip >= 0) & (self.cont_describe.hartigan_dip <= 0.05)
+            modal_vars = list(self.cont_describe.hartigan_dip[modal_mask].dropna(how="all").index)
             if modal_vars:
-                self._warnings["""Hartigan's Dip Test reports possible
-                                  multimodal distributions for"""] = modal_vars
+                self._warnings[
+                    """Hartigan's Dip Test reports possible
+                                  multimodal distributions for"""
+                ] = modal_vars
 
         if self._continuous and self._normal_test:
             # highlight non normal distributions
             # -1 values indicate NaN
-            modal_mask = ((self.cont_describe.normality >= 0) &
-                          (self.cont_describe.normality <= 0.001))
-            modal_vars = list(self.cont_describe.normality[modal_mask].
-                              dropna(how='all').index)
+            modal_mask = (self.cont_describe.normality >= 0) & (self.cont_describe.normality <= 0.001)
+            modal_vars = list(self.cont_describe.normality[modal_mask].dropna(how="all").index)
             if modal_vars:
-                self._warnings["""Normality test reports non-normal
-                                  distributions for"""] = modal_vars
+                self._warnings[
+                    """Normality test reports non-normal
+                                  distributions for"""
+                ] = modal_vars
 
         # create the warning string
-        msg = '{}'.format(newline)
+        msg = "{}".format(newline)
         for n, k in enumerate(sorted(self._warnings)):
-            msg += '[{}] {}: {}.{}'.format(n+1, k,
-                                           ', '.join(self._warnings[k]),
-                                           newline)
+            msg += "[{}] {}: {}.{}".format(n + 1, k, ", ".join(self._warnings[k]), newline)
 
         return msg
 
@@ -573,13 +591,14 @@ class TableOne:
         likely_cat = list(likely_cat - date_cols)
         # check proportion of unique values if numerical
         for var in data._get_numeric_data().columns:
-            likely_flag = 1.0 * data[var].nunique()/data[var].count() < 0.005
+            likely_flag = 1.0 * data[var].nunique() / data[var].count() < 0.005
             if likely_flag:
                 likely_cat.append(var)
         return likely_cat
 
-    def _cont_smd(self, data1=None, data2=None, mean1=None, mean2=None,
-                  sd1=None, sd2=None, n1=None, n2=None, unbiased=False):
+    def _cont_smd(
+        self, data1=None, data2=None, mean1=None, mean2=None, sd1=None, sd2=None, n1=None, n2=None, unbiased=False
+    ):
         """
         Compute the standardized mean difference (regular or unbiased) using
         either raw data or summary measures.
@@ -615,11 +634,13 @@ class TableOne:
             Standard error of the estimated standardized mean difference.
         """
         if (data1 and not data2) or (data2 and not data1):
-            raise InputError('Two sets of data must be provided.')
+            raise InputError("Two sets of data must be provided.")
         elif data1 and data2:
             if any([mean1, mean2, sd1, sd2, n1, n2]):
-                warnings.warn("""Mean, n, and sd were computed from the data.
-                                 These input args were ignored.""")
+                warnings.warn(
+                    """Mean, n, and sd were computed from the data.
+                                 These input args were ignored."""
+                )
             mean1 = np.mean(data1)
             mean2 = np.mean(data2)
             sd1 = np.std(data1)
@@ -637,10 +658,10 @@ class TableOne:
         #     raise InputError('n1 and n2 must both be provided.')
 
         # cohens_d
-        smd = (mean2 - mean1) / np.sqrt((sd1 ** 2 + sd2 ** 2) / 2)  # type: ignore
+        smd = (mean2 - mean1) / np.sqrt((sd1**2 + sd2**2) / 2)  # type: ignore
 
         # standard error
-        v_d = ((n1+n2) / (n1*n2)) + ((smd ** 2) / (2*(n1+n2)))  # type: ignore
+        v_d = ((n1 + n2) / (n1 * n2)) + ((smd**2) / (2 * (n1 + n2)))  # type: ignore
         se = np.sqrt(v_d)
 
         if unbiased:
@@ -649,15 +670,14 @@ class TableOne:
             # Introduction to Meta-Analysis. Michael Borenstein,
             # L. V. Hedges, J. P. T. Higgins and H. R. Rothstein
             # Wiley (2011). Chapter 4. Effect Sizes Based on Means.
-            j = 1 - (3/(4*(n1+n2-2)-1))  # type: ignore
+            j = 1 - (3 / (4 * (n1 + n2 - 2) - 1))  # type: ignore
             smd = j * smd
-            v_g = (j ** 2) * v_d
+            v_g = (j**2) * v_d
             se = np.sqrt(v_g)
 
         return smd, se
 
-    def _cat_smd(self, prop1=None, prop2=None, n1=None, n2=None,
-                 unbiased=False):
+    def _cat_smd(self, prop1=None, prop2=None, n1=None, n2=None, unbiased=False):
         """
         Compute the standardized mean difference (regular or unbiased) using
         either raw data or summary measures.
@@ -699,12 +719,12 @@ class TableOne:
         lst_cov = []
         for p in [prop1, prop2]:
             variance = p * (1 - p)
-            covariance = - np.outer(p, p)  # type: ignore
+            covariance = -np.outer(p, p)  # type: ignore
             covariance[np.diag_indices_from(covariance)] = variance
             lst_cov.append(covariance)
 
         mean_diff = np.asarray(prop2 - prop1).reshape((1, -1))  # type: ignore
-        mean_cov = (lst_cov[0] + lst_cov[1])/2
+        mean_cov = (lst_cov[0] + lst_cov[1]) / 2
 
         # TODO: add steps to deal with nulls
 
@@ -719,7 +739,7 @@ class TableOne:
             smd = np.nan
 
         # standard error
-        v_d = ((n1+n2) / (n1*n2)) + ((smd ** 2) / (2*(n1+n2)))  # type: ignore
+        v_d = ((n1 + n2) / (n1 * n2)) + ((smd**2) / (2 * (n1 + n2)))  # type: ignore
         se = np.sqrt(v_d)
 
         if unbiased:
@@ -728,9 +748,9 @@ class TableOne:
             # Introduction to Meta-Analysis. Michael Borenstein,
             # L. V. Hedges, J. P. T. Higgins and H. R. Rothstein
             # Wiley (2011). Chapter 4. Effect Sizes Based on Means.
-            j = 1 - (3/(4*(n1+n2-2)-1))  # type: ignore
+            j = 1 - (3 / (4 * (n1 + n2 - 2) - 1))  # type: ignore
             smd = j * smd
-            v_g = (j ** 2) * v_d
+            v_g = (j**2) * v_d
             se = np.sqrt(v_g)
 
         return smd, se
@@ -778,7 +798,7 @@ class TableOne:
         p < alpha suggests the null hypothesis can be rejected.
         """
         if len(x.values[~np.isnan(x.values)]) >= 20:
-            stat, p = stats.normaltest(x.values, nan_policy='omit')
+            stat, p = stats.normaltest(x.values, nan_policy="omit")
         else:
             p = None
         # dropna=False argument in pivot_table does not function as expected
@@ -846,14 +866,17 @@ class TableOne:
         else:
             n = 1
             msg = """The decimals arg must be an int or dict.
-                     Defaulting to {} d.p.""".format(n)
+                     Defaulting to {} d.p.""".format(
+                n
+            )
             warnings.warn(msg)
 
         if x.name in self._nonnormal:
             f = "{{:.{}f}} [{{:.{}f}},{{:.{}f}}]".format(n, n, n)
             if self._min_max and x.name in self._min_max:
                 return f.format(
-                    np.nanmedian(x.values), np.nanmin(x.values),  # type: ignore
+                    np.nanmedian(x.values),
+                    np.nanmin(x.values),  # type: ignore
                     np.nanmax(x.values),  # type: ignore
                 )
             else:
@@ -866,16 +889,15 @@ class TableOne:
             if self._min_max and x.name in self._min_max:
                 f = "{{:.{}f}} [{{:.{}f}},{{:.{}f}}]".format(n, n, n)
                 return f.format(
-                    np.nanmean(x.values), np.nanmin(x.values),  # type: ignore
+                    np.nanmean(x.values),
+                    np.nanmin(x.values),  # type: ignore
                     np.nanmax(x.values),  # type: ignore
                 )
             else:
-                f = '{{:.{}f}} ({{:.{}f}})'.format(n, n)
+                f = "{{:.{}f}} ({{:.{}f}})".format(n, n)
                 return f.format(np.nanmean(x.values), self._std(x))  # type: ignore
 
-    def _create_cont_describe(self,
-                              data: pd.DataFrame,
-                              groupby: Optional[str] = None) -> pd.DataFrame:
+    def _create_cont_describe(self, data: pd.DataFrame, groupby: Optional[str] = None) -> pd.DataFrame:
         """
         Describe the continuous data.
 
@@ -889,8 +911,7 @@ class TableOne:
             df_cont : pandas DataFrame
                 Summarise the continuous variables.
         """
-        aggfuncs = [pd.Series.count, np.mean, np.median, self._std,
-                    self._q25, self._q75, min, max, self._t1_summary]
+        aggfuncs = [pd.Series.count, np.mean, np.median, self._std, self._q25, self._q75, min, max, self._t1_summary]
 
         if self._dip_test:
             aggfuncs.append(self._hartigan_dip)
@@ -903,16 +924,17 @@ class TableOne:
             aggfuncs.append(self._normality)
 
         # coerce continuous data to numeric
-        cont_data = data[self._continuous].apply(pd.to_numeric,
-                                                 errors='coerce')
+        cont_data = data[self._continuous].apply(pd.to_numeric, errors="coerce")
         # check all data in each continuous column is numeric
         bad_cols = cont_data.count() != data[self._continuous].count()
         bad_cols = cont_data.columns[bad_cols]
         if len(bad_cols) > 0:
-            msg = ("The following continuous column(s) have "
-                   "non-numeric values: {variables}. Either specify the "
-                   "column(s) as categorical or remove the "
-                   "non-numeric values.").format(variables=bad_cols.values)
+            msg = (
+                "The following continuous column(s) have "
+                "non-numeric values: {variables}. Either specify the "
+                "column(s) as categorical or remove the "
+                "non-numeric values."
+            ).format(variables=bad_cols.values)
             raise InputError(msg)
 
         # check for coerced column containing all NaN to warn user
@@ -921,26 +943,21 @@ class TableOne:
 
         if groupby:
             # add the groupby column back
-            cont_data = cont_data.merge(data[[groupby]],
-                                        left_index=True,
-                                        right_index=True)
+            cont_data = cont_data.merge(data[[groupby]], left_index=True, right_index=True)
 
             # group and aggregate data
-            df_cont = pd.pivot_table(cont_data,
-                                     columns=[groupby],
-                                     aggfunc=aggfuncs)
+            df_cont = pd.pivot_table(cont_data, columns=[groupby], aggfunc=aggfuncs)
         else:
             # if no groupby, just add single group column
             df_cont = cont_data.apply(aggfuncs).T  # type: ignore
-            df_cont.columns.name = 'Overall'
-            df_cont.columns = pd.MultiIndex.from_product([df_cont.columns,
-                                                         ['Overall']])
+            df_cont.columns.name = "Overall"
+            df_cont.columns = pd.MultiIndex.from_product([df_cont.columns, ["Overall"]])
 
-        df_cont.index = df_cont.index.rename('variable')
+        df_cont.index = df_cont.index.rename("variable")
 
         # remove prefix underscore from column names (e.g. _std -> std)
         agg_rename = df_cont.columns.levels[0]  # type: ignore
-        agg_rename = [x[1:] if x[0] == '_' else x for x in agg_rename]
+        agg_rename = [x[1:] if x[0] == "_" else x for x in agg_rename]
         df_cont.columns = df_cont.columns.set_levels(agg_rename, level=0)  # type: ignore
 
         return df_cont
@@ -954,12 +971,12 @@ class TableOne:
             n = self._decimals[var]  # type: ignore
         else:
             n = 1
-        f = '{{:.{}f}}'.format(n)
+        f = "{{:.{}f}}".format(n)
         return f.format(row[col])
 
-    def _create_cat_describe(self, data: pd.DataFrame,
-                             groupby: Optional[str] = None,
-                             groupbylvls: Optional[list] = None) -> pd.DataFrame:
+    def _create_cat_describe(
+        self, data: pd.DataFrame, groupby: Optional[str] = None, groupbylvls: Optional[list] = None
+    ) -> pd.DataFrame:
         """
         Describe the categorical data.
 
@@ -989,73 +1006,60 @@ class TableOne:
 
             # create n column and null count column
             # must be done before converting values to strings
-            ct = df.count().to_frame(name='n')
-            ct.index.name = 'variable'
-            nulls = df.isnull().sum().to_frame(name='Missing')
-            nulls.index.name = 'variable'
+            ct = df.count().to_frame(name="n")
+            ct.index.name = "variable"
+            nulls = df.isnull().sum().to_frame(name="Missing")
+            nulls.index.name = "variable"
 
             # Convert to str to handle int converted to boolean in the index.
             # Also avoid nans.
             for column in df.columns:
-                df[column] = [str(row) if not pd.isnull(row)
-                              else None for row in df[column].values]
-                cat_slice[column] = [str(row) if not pd.isnull(row)
-                                     else None for row
-                                     in cat_slice[column].values]
+                df[column] = [str(row) if not pd.isnull(row) else None for row in df[column].values]
+                cat_slice[column] = [str(row) if not pd.isnull(row) else None for row in cat_slice[column].values]
 
             # create a dataframe with freq, proportion
-            df = df.melt().groupby(['variable',
-                                    'value']).size().to_frame(name='freq')
+            df = df.melt().groupby(["variable", "value"]).size().to_frame(name="freq")
 
-            df['percent'] = df['freq'].div(df.groupby(level=0).freq.sum(),
-                                           level=0).astype(float) * 100
+            # table = pd.concat([pd.DataFrame([[pd.NA]], columns=['freq'], index=[(0,' ')]), table])
+            df["percent"] = df["freq"].div(df.groupby(level=0).freq.sum(), level=0).astype(float) * 100
 
             # add row percent
-            df['percent_row'] = df['freq'].div(cat_slice[self._categorical]
-                                               .melt()
-                                               .groupby(['variable', 'value'])
-                                               .size()) * 100
+            df["percent_row"] = (
+                df["freq"].div(cat_slice[self._categorical].melt().groupby(["variable", "value"]).size()) * 100
+            )
 
             # set number of decimal places for percent
             if isinstance(self._decimals, int):
                 n = self._decimals
-                f = '{{:.{}f}}'.format(n)
-                df['percent_str'] = df['percent'].astype(float).map(f.format)
-                df['percent_row_str'] = df['percent_row'].astype(float).map(
-                    f.format)
+                f = "{{:.{}f}}".format(n)
+                df["percent_str"] = df["percent"].astype(float).map(f.format)
+                df["percent_row_str"] = df["percent_row"].astype(float).map(f.format)
             elif isinstance(self._decimals, dict):
-                df.loc[:, 'percent_str'] = df.apply(self._format_cat, axis=1,
-                                                    args=['percent'])
-                df.loc[:, 'percent_row_str'] = df.apply(self._format_cat,
-                                                        axis=1,
-                                                        args=['percent_row'])
+                df.loc[:, "percent_str"] = df.apply(self._format_cat, axis=1, args=["percent"])
+                df.loc[:, "percent_row_str"] = df.apply(self._format_cat, axis=1, args=["percent_row"])
             else:
                 n = 1
-                f = '{{:.{}f}}'.format(n)
-                df['percent_str'] = df['percent'].astype(float).map(f.format)
-                df['percent_row_str'] = df['percent_row'].astype(float).map(
-                    f.format)
+                f = "{{:.{}f}}".format(n)
+                df["percent_str"] = df["percent"].astype(float).map(f.format)
+                df["percent_row_str"] = df["percent_row"].astype(float).map(f.format)
 
             # join count column
             df = df.join(ct)
 
             # only save null count to the first category for each variable
             # do this by extracting the first category from the df row index
-            levels = df.reset_index()[['variable',
-                                       'value']].groupby('variable').first()
+            levels = df.reset_index()[["variable", "value"]].groupby("variable").first()
             # add this category to the nulls table
             nulls = nulls.join(levels)
-            nulls = nulls.set_index('value', append=True)
+            nulls = nulls.set_index("value", append=True)
             # join nulls to categorical
             df = df.join(nulls)
 
             # add summary column
             if self._row_percent:
-                df['t1_summary'] = (df.freq.map(str) + ' ('
-                                    + df.percent_row_str.map(str)+')')
+                df["t1_summary"] = df.freq.map(str) + " (" + df.percent_row_str.map(str) + ")"
             else:
-                df['t1_summary'] = (df.freq.map(str) + ' ('
-                                    + df.percent_str.map(str)+')')
+                df["t1_summary"] = df.freq.map(str) + " (" + df.percent_str.map(str) + ")"
 
             # add to dictionary
             group_dict[g] = df
@@ -1083,22 +1087,21 @@ class TableOne:
                 A table containing the P-Values, test name, etc.
         """
         # list features of the variable e.g. matched, paired, n_expected
-        df = pd.DataFrame(index=self._continuous+self._categorical,
-                          columns=['continuous', 'nonnormal',
-                                   'min_observed', 'P-Value', 'Test'])
+        df = pd.DataFrame(
+            index=self._continuous + self._categorical,
+            columns=["continuous", "nonnormal", "min_observed", "P-Value", "Test"],
+        )
 
-        df.index = df.index.rename('variable')
-        df['continuous'] = np.where(df.index.isin(self._continuous),
-                                    True, False)
+        df.index = df.index.rename("variable")
+        df["continuous"] = np.where(df.index.isin(self._continuous), True, False)
 
-        df['nonnormal'] = np.where(df.index.isin(self._nonnormal),
-                                   True, False)
+        df["nonnormal"] = np.where(df.index.isin(self._nonnormal), True, False)
 
         # list values for each variable, grouped by groupby levels
         for v in df.index:
-            is_continuous = df.loc[v]['continuous']
-            is_categorical = ~df.loc[v]['continuous']
-            is_normal = ~df.loc[v]['nonnormal']
+            is_continuous = df.loc[v]["continuous"]
+            is_categorical = ~df.loc[v]["continuous"]
+            is_normal = ~df.loc[v]["nonnormal"]
 
             # if continuous, group data into list of lists
             if is_continuous:
@@ -1107,28 +1110,24 @@ class TableOne:
                 for s in self._groupbylvls:
                     lvl_data = data.loc[data[self._groupby] == s, v]
                     # coerce to numeric and drop non-numeric data
-                    lvl_data = lvl_data.apply(pd.to_numeric,
-                                              errors='coerce').dropna()
+                    lvl_data = lvl_data.apply(pd.to_numeric, errors="coerce").dropna()
                     # append to overall group data
                     grouped_data[s] = lvl_data.values
                 min_observed = min([len(x) for x in grouped_data.values()])
             # if categorical, create contingency table
             elif is_categorical:
-                catlevels = sorted(data[v].astype('category').cat.categories)
-                cross_tab = pd.crosstab(data[self._groupby].
-                                        rename('_groupby_var_'), data[v])
+                catlevels = sorted(data[v].astype("category").cat.categories)
+                cross_tab = pd.crosstab(data[self._groupby].rename("_groupby_var_"), data[v])
                 min_observed = cross_tab.sum(axis=1).min()
-                grouped_data = cross_tab.T.to_dict('list')
+                grouped_data = cross_tab.T.to_dict("list")
 
             # minimum number of observations across all levels
-            df.loc[v, 'min_observed'] = min_observed  # type: ignore
+            df.loc[v, "min_observed"] = min_observed  # type: ignore
 
             # compute pvalues
-            (df.loc[v, 'P-Value'],
-                df.loc[v, 'Test']) = self._p_test(v, grouped_data,  # type: ignore
-                                                  is_continuous,
-                                                  is_categorical, is_normal,
-                                                  min_observed, catlevels)  # type: ignore
+            (df.loc[v, "P-Value"], df.loc[v, "Test"]) = self._p_test(
+                v, grouped_data, is_continuous, is_categorical, is_normal, min_observed, catlevels  # type: ignore
+            )  # type: ignore
 
         return df
 
@@ -1149,30 +1148,32 @@ class TableOne:
                 (SMDs).
         """
         # create the SMD table
-        permutations = [sorted((x, y),
-                        key=lambda f: self._groupbylvls.index(f))
-                        for x in self._groupbylvls
-                        for y in self._groupbylvls if x is not y]
+        permutations = [
+            sorted((x, y), key=lambda f: self._groupbylvls.index(f))
+            for x in self._groupbylvls
+            for y in self._groupbylvls
+            if x is not y
+        ]
 
         p_set = set(tuple(x) for x in permutations)
 
-        colname = 'SMD ({0},{1})'
+        colname = "SMD ({0},{1})"
         columns = [colname.format(x[0], x[1]) for x in p_set]
-        df = pd.DataFrame(index=self._continuous+self._categorical,
-                          columns=columns)
-        df.index = df.index.rename('variable')
+        df = pd.DataFrame(index=self._continuous + self._categorical, columns=columns)
+        df.index = df.index.rename("variable")
 
         for p in p_set:
             try:
                 for v in self.cont_describe.index:
                     smd, _ = self._cont_smd(
-                                mean1=self.cont_describe['mean'][p[0]].loc[v],
-                                mean2=self.cont_describe['mean'][p[1]].loc[v],
-                                sd1=self.cont_describe['std'][p[0]].loc[v],
-                                sd2=self.cont_describe['std'][p[1]].loc[v],
-                                n1=self.cont_describe['count'][p[0]].loc[v],
-                                n2=self.cont_describe['count'][p[1]].loc[v],
-                                unbiased=False)
+                        mean1=self.cont_describe["mean"][p[0]].loc[v],
+                        mean2=self.cont_describe["mean"][p[1]].loc[v],
+                        sd1=self.cont_describe["std"][p[0]].loc[v],
+                        sd2=self.cont_describe["std"][p[1]].loc[v],
+                        n1=self.cont_describe["count"][p[0]].loc[v],
+                        n2=self.cont_describe["count"][p[1]].loc[v],
+                        unbiased=False,
+                    )
                     df[colname.format(p[0], p[1])].loc[v] = smd
             except AttributeError:
                 pass
@@ -1180,26 +1181,28 @@ class TableOne:
             try:
                 for v, _ in self.cat_describe.groupby(level=0):
                     smd, _ = self._cat_smd(
-                        prop1=self.cat_describe.loc[[v]]['percent'][p[0]]
-                        .values/100,
-                        prop2=self.cat_describe.loc[[v]]['percent'][p[1]]
-                        .values/100,
-                        n1=self.cat_describe.loc[[v]]['freq'][p[0]].sum(),
-                        n2=self.cat_describe.loc[[v]]['freq'][p[1]].sum(),
-                        unbiased=False)
+                        prop1=self.cat_describe.loc[[v]]["percent"][p[0]].values / 100,
+                        prop2=self.cat_describe.loc[[v]]["percent"][p[1]].values / 100,
+                        n1=self.cat_describe.loc[[v]]["freq"][p[0]].sum(),
+                        n2=self.cat_describe.loc[[v]]["freq"][p[1]].sum(),
+                        unbiased=False,
+                    )
                     df[colname.format(p[0], p[1])].loc[v] = smd  # type: ignore
             except AttributeError:
                 pass
 
         return df
 
-    def _p_test(self, v: str,
-                grouped_data: dict,
-                is_continuous: bool,
-                is_categorical: bool,
-                is_normal: bool,
-                min_observed: int,
-                catlevels: list):
+    def _p_test(
+        self,
+        v: str,
+        grouped_data: dict,
+        is_continuous: bool,
+        is_categorical: bool,
+        is_normal: bool,
+        min_observed: int,
+        catlevels: list,
+    ):
         """
         Compute P-Values.
 
@@ -1230,7 +1233,7 @@ class TableOne:
 
         # no test by default
         pval = np.nan
-        ptest = 'Not tested'
+        ptest = "Not tested"
 
         # apply user defined test
         if self._htest and v in self._htest:
@@ -1240,33 +1243,30 @@ class TableOne:
 
         # do not test if the variable has no observations in a level
         if min_observed == 0:
-            msg = ("No P-Value was computed for {variable} due to the low "
-                   "number of observations.""").format(variable=v)
+            msg = ("No P-Value was computed for {variable} due to the low " "number of observations." "").format(
+                variable=v
+            )
             warnings.warn(msg)
             return pval, ptest
 
         # continuous
-        if (is_continuous and is_normal and len(grouped_data) == 2
-                and min_observed >= 2):
-            ptest = 'Two Sample T-test'
-            test_stat, pval = stats.ttest_ind(*grouped_data.values(),
-                                              equal_var=False,
-                                              nan_policy="omit")
+        if is_continuous and is_normal and len(grouped_data) == 2 and min_observed >= 2:
+            ptest = "Two Sample T-test"
+            test_stat, pval = stats.ttest_ind(*grouped_data.values(), equal_var=False, nan_policy="omit")
         elif is_continuous and is_normal:
             # normally distributed
-            ptest = 'One-way ANOVA'
+            ptest = "One-way ANOVA"
             test_stat, pval = stats.f_oneway(*grouped_data.values())
         elif is_continuous and not is_normal:
             # non-normally distributed
-            ptest = 'Kruskal-Wallis'
+            ptest = "Kruskal-Wallis"
             test_stat, pval = stats.kruskal(*grouped_data.values())
         # categorical
         elif is_categorical:
             # default to chi-squared
-            ptest = 'Chi-squared'
+            ptest = "Chi-squared"
             grouped_val_list = [x for x in grouped_data.values()]
-            _, pval, _, expected = stats.chi2_contingency(
-                grouped_val_list)
+            _, pval, _, expected = stats.chi2_contingency(grouped_val_list)
             # if any expected cell counts are < 5, chi2 may not be valid
             # if this is a 2x2, switch to fisher exact
             if expected.min() < 5 or min_observed < 5:
@@ -1275,9 +1275,11 @@ class TableOne:
                     odds_ratio, pval = stats.fisher_exact(grouped_val_list)
                 else:
                     ptest = "Chi-squared (warning: expected count < 5)"
-                    chi_warn = ("Chi-squared tests for the following "
-                                "variables may be invalid due to the low "
-                                "number of observations")
+                    chi_warn = (
+                        "Chi-squared tests for the following "
+                        "variables may be invalid due to the low "
+                        "number of observations"
+                    )
                     try:
                         self._warnings[chi_warn].append(v)
                     except KeyError:
@@ -1295,12 +1297,11 @@ class TableOne:
             A table summarising the continuous variables.
         """
         # remove the t1_summary level
-        table = self.cont_describe[['t1_summary']].copy()
+        table = self.cont_describe[["t1_summary"]].copy()
         table.columns = table.columns.droplevel(level=0)
 
         # add a column of null counts as 1-count() from previous function
-        nulltable = data[self._continuous].isnull().sum().to_frame(
-            name='Missing')
+        nulltable = data[self._continuous].isnull().sum().to_frame(name="Missing")
         try:
             table = table.join(nulltable)
         # if columns form a CategoricalIndex, need to convert to string first
@@ -1309,15 +1310,14 @@ class TableOne:
             table = table.join(nulltable)
 
         # add an empty value column, for joining with cat table
-        table['value'] = ''
-        table = table.set_index([table.index, 'value'])  # type: ignore
+        table["value"] = ""
+        table = table.set_index([table.index, "value"])  # type: ignore
 
         # add pval column
         if self._pval and self._pval_adjust:
-            table = table.join(self._htest_table[['P-Value (adjusted)',
-                                                  'Test']])
+            table = table.join(self._htest_table[["P-Value (adjusted)", "Test"]])
         elif self._pval:
-            table = table.join(self._htest_table[['P-Value', 'Test']])
+            table = table.join(self._htest_table[["P-Value", "Test"]])
 
         # add standardized mean difference (SMD) column/s
         if self._smd:
@@ -1325,8 +1325,7 @@ class TableOne:
 
         # join the overall column if needed
         if self._groupby and overall:
-            table = table.join(pd.concat([self.cont_describe_all['t1_summary'].
-                                          Overall], axis=1, keys=["Overall"]))
+            table = table.join(pd.concat([self.cont_describe_all["t1_summary"].Overall], axis=1, keys=["Overall"]))
 
         return table
 
@@ -1339,12 +1338,11 @@ class TableOne:
         table : pandas DataFrame
             A table summarising the categorical variables.
         """
-        table = self.cat_describe['t1_summary'].copy()
+        table = self.cat_describe["t1_summary"].copy()
 
         # add the total count of null values across all levels
-        isnull = data[self._categorical].isnull().sum().to_frame(
-            name='Missing')
-        isnull.index = isnull.index.rename('variable')
+        isnull = data[self._categorical].isnull().sum().to_frame(name="Missing")
+        isnull.index = isnull.index.rename("variable")
         try:
             table = table.join(isnull)
         # if columns form a CategoricalIndex, need to convert to string first
@@ -1354,10 +1352,9 @@ class TableOne:
 
         # add pval column
         if self._pval and self._pval_adjust:
-            table = table.join(self._htest_table[['P-Value (adjusted)',
-                                                  'Test']])
+            table = table.join(self._htest_table[["P-Value (adjusted)", "Test"]])
         elif self._pval:
-            table = table.join(self._htest_table[['P-Value', 'Test']])
+            table = table.join(self._htest_table[["P-Value", "Test"]])
 
         # add standardized mean difference (SMD) column/s
         if self._smd:
@@ -1365,9 +1362,16 @@ class TableOne:
 
         # join the overall column if needed
         if self._groupby and overall:
-            table = table.join(pd.concat([self.cat_describe_all['t1_summary'].
-                                          Overall], axis=1, keys=["Overall"]))
+            table = table.join(pd.concat([self.cat_describe_all["t1_summary"].Overall], axis=1, keys=["Overall"]))
 
+        # NOTE(Min): hackery?
+        for variable in isnull.index.values.tolist():
+            line = pd.DataFrame(
+                {"Missing": isnull.loc[variable]["Missing"], "Overall": pd.NA}, index=[(variable, " ")]
+            )
+            table = pd.concat([table, line], ignore_index=False)
+        table = table.sort_index()
+        # table = pd.concat([pd.DataFrame([[" ", isnull.values[0][0]]], columns=table.columns, index=[(0, " ")]), table])
         return table
 
     def _create_tableone(self, data):
@@ -1382,8 +1386,7 @@ class TableOne:
         if self._continuous and self._categorical:
             # support pandas<=0.22
             try:
-                table = pd.concat([self.cont_table, self.cat_table],
-                                  sort=False)
+                table = pd.concat([self.cont_table, self.cat_table], sort=False)
             except TypeError:
                 table = pd.concat([self.cont_table, self.cat_table])
         elif self._continuous:
@@ -1392,73 +1395,63 @@ class TableOne:
             table = self.cat_table
 
         # ensure column headers are strings before reindexing
-        table = table.reset_index().set_index(['variable', 'value'])  # type: ignore
+        # table = table.reset_index().set_index(["variable", "value"])  # type: ignore
         table.columns = table.columns.values.astype(str)
 
         # sort the table rows
-        sort_columns = ['Missing', 'P-Value', 'P-Value (adjusted)', 'Test']
+        sort_columns = ["Missing", "P-Value", "P-Value (adjusted)", "Test"]
         if self._smd:
             sort_columns = sort_columns + list(self.smd_table.columns)
 
         if self._sort and isinstance(self._sort, bool):
             new_index = sorted(table.index.values, key=lambda x: x[0].lower())
-        elif self._sort and isinstance(self._sort, str) and (self._sort in
-                                                             sort_columns):
+        elif self._sort and isinstance(self._sort, str) and (self._sort in sort_columns):
             try:
                 new_index = table.sort_values(self._sort).index
             except KeyError:
-                new_index = sorted(table.index.values,
-                                   key=lambda x: self._columns.index(x[0]))
-                warnings.warn('Sort variable not found: {}'.format(self._sort))
-        elif self._sort and isinstance(self._sort, str) and (self._sort not in
-                                                             sort_columns):
-            new_index = sorted(table.index.values,
-                               key=lambda x: self._columns.index(x[0]))
-            warnings.warn('Sort must be in the following ' +
-                          'list: {}.'.format(self._sort))
+                new_index = sorted(table.index.values, key=lambda x: self._columns.index(x[0]))
+                warnings.warn("Sort variable not found: {}".format(self._sort))
+        elif self._sort and isinstance(self._sort, str) and (self._sort not in sort_columns):
+            new_index = sorted(table.index.values, key=lambda x: self._columns.index(x[0]))
+            warnings.warn("Sort must be in the following " + "list: {}.".format(self._sort))
         else:
             # sort by the columns argument
-            new_index = sorted(table.index.values,
-                               key=lambda x: self._columns.index(x[0]))
+            new_index = sorted(table.index.values, key=lambda x: self._columns.index(x[0]))
         table = table.reindex(new_index)
 
         # round pval column and convert to string
         if self._pval and self._pval_adjust:
             if self._pval_threshold:
-                asterisk_mask = table['P-Value (adjusted)'] < self._pval_threshold
+                asterisk_mask = table["P-Value (adjusted)"] < self._pval_threshold
 
-            table['P-Value (adjusted)'] = table['P-Value (adjusted)'].apply(
-                                                '{:.3f}'.format).astype(str)
-            table.loc[table['P-Value (adjusted)'] == '0.000',
-                      'P-Value (adjusted)'] = '<0.001'
+            table["P-Value (adjusted)"] = table["P-Value (adjusted)"].apply("{:.3f}".format).astype(str)
+            table.loc[table["P-Value (adjusted)"] == "0.000", "P-Value (adjusted)"] = "<0.001"
 
             if self._pval_threshold:
-                table.loc[asterisk_mask, 'P-Value (adjusted)'] = table['P-Value (adjusted)'][asterisk_mask].astype(str)+"*"  # type: ignore
+                table.loc[asterisk_mask, "P-Value (adjusted)"] = table["P-Value (adjusted)"][asterisk_mask].astype(str) + "*"  # type: ignore
 
         elif self._pval:
             if self._pval_threshold:
-                asterisk_mask = table['P-Value'] < self._pval_threshold
+                asterisk_mask = table["P-Value"] < self._pval_threshold
 
-            table['P-Value'] = table['P-Value'].apply(
-                                     '{:.3f}'.format).astype(str)
-            table.loc[table['P-Value'] == '0.000', 'P-Value'] = '<0.001'
+            table["P-Value"] = table["P-Value"].apply("{:.3f}".format).astype(str)
+            table.loc[table["P-Value"] == "0.000", "P-Value"] = "<0.001"
 
             if self._pval_threshold:
-                table.loc[asterisk_mask, 'P-Value'] = table['P-Value'][asterisk_mask].astype(str)+"*"  # type: ignore
+                table.loc[asterisk_mask, "P-Value"] = table["P-Value"][asterisk_mask].astype(str) + "*"  # type: ignore
 
         # round smd columns and convert to string
         if self._smd:
             for c in list(self.smd_table.columns):
-                table[c] = table[c].apply('{:.3f}'.format).astype(str)
-                table.loc[table[c] == '0.000', c] = '<0.001'
+                table[c] = table[c].apply("{:.3f}".format).astype(str)
+                table.loc[table[c] == "0.000", c] = "<0.001"
 
         # if an order is specified, apply it
         if self._order:
             for k in self._order:
-
                 # Skip if the variable isn't present
                 try:
-                    all_var = table.loc[k].index.unique(level='value')
+                    all_var = table.loc[k].index.unique(level="value")
                 except KeyError:
                     if k not in self._groupby:  # type: ignore
                         warnings.warn("Order variable not found: {}".format(k))
@@ -1467,14 +1460,11 @@ class TableOne:
                 # Remove value from order if it is not present
                 if [i for i in self._order[k] if i not in all_var]:
                     rm_var = [i for i in self._order[k] if i not in all_var]
-                    self._order[k] = [i for i in self._order[k]
-                                      if i in all_var]
-                    warnings.warn(("Order value not found: "
-                                   "{}: {}").format(k, rm_var))
+                    self._order[k] = [i for i in self._order[k] if i in all_var]
+                    warnings.warn(("Order value not found: " "{}: {}").format(k, rm_var))
 
-                new_seq = [(k, '{}'.format(v)) for v in self._order[k]]
-                new_seq += [(k, '{}'.format(v)) for v in all_var
-                            if v not in self._order[k]]
+                new_seq = [(k, "{}".format(v)) for v in self._order[k]]
+                new_seq += [(k, "{}".format(v)) for v in all_var if v not in self._order[k]]
 
                 # restructure to match the original idx
                 new_idx_array = np.empty((len(new_seq),), dtype=object)
@@ -1489,8 +1479,7 @@ class TableOne:
 
             for k, _ in levelcounts.items():
                 # set the limit for the variable
-                if (isinstance(self._limit, int)
-                        and levelcounts[k] >= self._limit):
+                if isinstance(self._limit, int) and levelcounts[k] >= self._limit:
                     limit = self._limit
                 elif isinstance(self._limit, dict) and k in self._limit:
                     limit = self._limit[k]
@@ -1500,13 +1489,12 @@ class TableOne:
                 if not self._order or (self._order and k not in self._order):
                     # re-order the variables by frequency
                     count = data[k].value_counts().sort_values(ascending=False)
-                    new_idx = [(k, '{}'.format(i)) for i in count.index]
+                    new_idx = [(k, "{}".format(i)) for i in count.index]
                 else:
                     # apply order
-                    all_var = table.loc[k].index.unique(level='value')
-                    new_idx = [(k, '{}'.format(v)) for v in self._order[k]]
-                    new_idx += [(k, '{}'.format(v)) for v in all_var
-                                if v not in self._order[k]]
+                    all_var = table.loc[k].index.unique(level="value")
+                    new_idx = [(k, "{}".format(v)) for v in self._order[k]]
+                    new_idx += [(k, "{}".format(v)) for v in all_var if v not in self._order[k]]
 
                 # restructure to match the original idx
                 new_idx_array = np.empty((len(new_idx),), dtype=object)
@@ -1519,9 +1507,9 @@ class TableOne:
                 table = table.drop(new_idx_array[limit:])
 
         # insert n row
-        n_row = pd.DataFrame(columns=['variable', 'value', 'Missing'])
-        n_row = n_row.set_index(['variable', 'value'])
-        n_row.loc['n', 'Missing'] = None
+        n_row = pd.DataFrame(columns=["variable", "value", "Missing"])
+        n_row = n_row.set_index(["variable", "value"])
+        n_row.loc["n", "Missing"] = None
 
         # support pandas<=0.22
         try:
@@ -1529,46 +1517,46 @@ class TableOne:
         except TypeError:
             table = pd.concat([n_row, table])
 
-        if self._groupbylvls == ['Overall']:
-            table.loc['n', 'Overall'] = len(data.index)
+        if self._groupbylvls == ["Overall"]:
+            table.loc["n", "Overall"] = len(data.index)
         else:
             if self._overall:
-                table.loc['n', 'Overall'] = len(data.index)
+                table.loc["n", "Overall"] = len(data.index)
             for g in self._groupbylvls:
                 ct = data[self._groupby][data[self._groupby] == g].count()
-                table.loc['n', '{}'.format(g)] = ct
+                table.loc["n", "{}".format(g)] = ct
 
         # only display data in first level row
         dupe_mask = table.groupby(level=[0]).cumcount().ne(0)  # type: ignore
-        dupe_columns = ['Missing']
-        optional_columns = ['P-Value', 'P-Value (adjusted)', 'Test']
+        dupe_columns = ["Missing"]
+        optional_columns = ["P-Value", "P-Value (adjusted)", "Test"]
         if self._smd:
             optional_columns = optional_columns + list(self.smd_table.columns)
         for col in optional_columns:
             if col in table.columns.values:
                 dupe_columns.append(col)
 
-        table[dupe_columns] = table[dupe_columns].mask(dupe_mask).fillna('')
+        table[dupe_columns] = table[dupe_columns].mask(dupe_mask).fillna("")
 
         # remove Missing column if not needed
         if not self._isnull:
-            table = table.drop('Missing', axis=1)
+            table = table.drop("Missing", axis=1)
 
         if self._pval and not self._pval_test_name:
-            table = table.drop('Test', axis=1)
+            table = table.drop("Test", axis=1)
 
         # replace nans with empty strings
-        table = table.fillna('')
+        table = table.fillna("")
 
         # add column index
-        if not self._groupbylvls == ['Overall']:
+        if not self._groupbylvls == ["Overall"]:
             # rename groupby variable if requested
             c = self._groupby
             if self._alt_labels:
                 if self._groupby in self._alt_labels:
                     c = self._alt_labels[self._groupby]
 
-            c = 'Grouped by {}'.format(c)
+            c = "Grouped by {}".format(c)
             table.columns = pd.MultiIndex.from_product([[c], table.columns])
 
         # display alternative labels if assigned
@@ -1576,21 +1564,18 @@ class TableOne:
 
         # ensure the order of columns is consistent
         if self._groupby and self._order and (self._groupby in self._order):
-            header = ['{}'.format(v) for v in table.columns.levels[1].values]  # type: ignore
-            cols = self._order[self._groupby] + ['{}'.format(v)
-                                                 for v in header
-                                                 if v not in
-                                                 self._order[self._groupby]]
+            header = ["{}".format(v) for v in table.columns.levels[1].values]  # type: ignore
+            cols = self._order[self._groupby] + ["{}".format(v) for v in header if v not in self._order[self._groupby]]
         elif self._groupby:
-            cols = ['{}'.format(v) for v in table.columns.levels[1].values]  # type: ignore
+            cols = ["{}".format(v) for v in table.columns.levels[1].values]  # type: ignore
         else:
-            cols = ['{}'.format(v) for v in table.columns.values]
+            cols = ["{}".format(v) for v in table.columns.values]
 
         if self._groupby and self._overall:
-            cols = ['Overall'] + [x for x in cols if x != 'Overall']
+            cols = ["Overall"] + [x for x in cols if x != "Overall"]
 
-        if 'Missing' in cols:
-            cols = ['Missing'] + [x for x in cols if x != 'Missing']
+        if "Missing" in cols:
+            cols = ["Missing"] + [x for x in cols if x != "Missing"]
 
         # move optional_columns to the end of the dataframe
         for col in optional_columns:
@@ -1603,7 +1588,7 @@ class TableOne:
             table = table.reindex(cols, axis=1)
 
         try:
-            if 'Missing' in self._alt_labels or 'Overall' in self._alt_labels:  # type: ignore
+            if "Missing" in self._alt_labels or "Overall" in self._alt_labels:  # type: ignore
                 table = table.rename(columns=self._alt_labels)
         except TypeError:
             pass
@@ -1639,27 +1624,24 @@ class TableOne:
             for k in labels.keys():
                 if k in self._nonnormal:
                     if self._min_max and k in self._min_max:
-                        labels[k] = "{}, {}".format(labels[k],
-                                                    "median [min,max]")
+                        labels[k] = "{}, {}".format(labels[k], "median [min,max]")
                     else:
-                        labels[k] = "{}, {}".format(labels[k],
-                                                    "median [Q1,Q3]")
+                        labels[k] = "{}, {}".format(labels[k], "median [Q1,Q3]")
                 elif k in self._categorical:
                     labels[k] = "{}, {}".format(labels[k], "n (%)")
                 else:
                     if self._min_max and k in self._min_max:
-                        labels[k] = "{}, {}".format(labels[k],
-                                                    "mean [min,max]")
+                        labels[k] = "{}, {}".format(labels[k], "mean [min,max]")
                     else:
-                        labels[k] = "{}, {}".format(labels[k],
-                                                    "mean (SD)")
+                        labels[k] = "{}, {}".format(labels[k], "mean (SD)")
 
         return labels
 
     # warnings
     def _non_continuous_warning(self, c):
-        msg = ("'{}' has all non-numeric values. Consider including "
-               "it in the list of categorical variables.").format(c)
+        msg = (
+            "'{}' has all non-numeric values. Consider including " "it in the list of categorical variables."
+        ).format(c)
         warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
 

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -1029,10 +1029,7 @@ class TestTableOne(object):
         group = "Grouped by even"
         col = "P-Value (adjusted)"
         for k in pvals_expected:
-            values = t1.tableone.loc[k][group][col].values.tolist()
-            if "nan" in values:
-                values.remove("nan")
-            assert values[0] == pvals_expected[k]
+            assert t1.tableone.loc[k][group][col].values[0] == pvals_expected[k]
 
         # catch the pval_adjust=True
         with warnings.catch_warnings(record=False):
@@ -1040,10 +1037,7 @@ class TestTableOne(object):
             TableOne(df, groupby="even", pval=True, pval_adjust=True)
 
         for k in pvals_expected:
-            values = t1.tableone.loc[k][group][col].values.tolist()
-            if "nan" in values:
-                values.remove("nan")
-            assert values[0] == pvals_expected[k]
+            assert t1.tableone.loc[k][group][col].values[0] == pvals_expected[k]
 
     def test_pval_correction(self):
         """
@@ -1220,7 +1214,7 @@ class TestTableOne(object):
         exp_smd = {"ICU": "0.747", "MechVent": "nan", "death": "0.017"}
 
         for k in exp_smd:
-            smd = t.tableone.loc[k, "Grouped by MechVent"]["SMD (0,1)"][1]
+            smd = t.tableone.loc[k, "Grouped by MechVent"]["SMD (0,1)"][0]
             assert smd == exp_smd[k]
 
     def test_compute_standardized_mean_difference_categorical(self, data_pn):

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -15,7 +15,7 @@ seed = 12345
 
 @pytest.fixture(scope="function")
 def data_pn():
-    return load_dataset('pn2012')
+    return load_dataset("pn2012")
 
 
 @pytest.fixture(scope="function")
@@ -27,33 +27,30 @@ def data_sample(n=10000):
     np.random.seed(seed)
 
     mu, sigma = 10, 1
-    data_sample['normal'] = np.random.normal(mu, sigma, n)
-    data_sample['nonnormal'] = np.random.noncentral_chisquare(20, nonc=2,
-                                                              size=n)
+    data_sample["normal"] = np.random.normal(mu, sigma, n)
+    data_sample["nonnormal"] = np.random.noncentral_chisquare(20, nonc=2, size=n)
 
-    bears = ['Winnie', 'Paddington', 'Baloo', 'Blossom']
-    data_sample['bear'] = np.random.choice(bears, n,
-                                           p=[0.5, 0.1, 0.1, 0.3])
+    bears = ["Winnie", "Paddington", "Baloo", "Blossom"]
+    data_sample["bear"] = np.random.choice(bears, n, p=[0.5, 0.1, 0.1, 0.3])
 
-    data_sample['likeshoney'] = np.nan
-    data_sample.loc[data_sample['bear'] == 'Winnie', 'likeshoney'] = 1
-    data_sample.loc[data_sample['bear'] == 'Baloo', 'likeshoney'] = 1
+    data_sample["likeshoney"] = np.nan
+    data_sample.loc[data_sample["bear"] == "Winnie", "likeshoney"] = 1
+    data_sample.loc[data_sample["bear"] == "Baloo", "likeshoney"] = 1
 
-    data_sample['likesmarmalade'] = 0
-    data_sample.loc[data_sample['bear'] == 'Paddington',
-                                           'likesmarmalade'] = 1
+    data_sample["likesmarmalade"] = 0
+    data_sample.loc[data_sample["bear"] == "Paddington", "likesmarmalade"] = 1
 
-    data_sample['height'] = 0
-    data_sample.loc[data_sample['bear'] == 'Winnie', 'height'] = 6
-    data_sample.loc[data_sample['bear'] == 'Paddington', 'height'] = 4
-    data_sample.loc[data_sample['bear'] == 'Baloo', 'height'] = 20
-    data_sample.loc[data_sample['bear'] == 'Blossom', 'height'] = 7
+    data_sample["height"] = 0
+    data_sample.loc[data_sample["bear"] == "Winnie", "height"] = 6
+    data_sample.loc[data_sample["bear"] == "Paddington", "height"] = 4
+    data_sample.loc[data_sample["bear"] == "Baloo", "height"] = 20
+    data_sample.loc[data_sample["bear"] == "Blossom", "height"] = 7
 
-    data_sample['fictional'] = 0
-    data_sample.loc[data_sample['bear'] == 'Winnie', 'fictional'] = 1
-    data_sample.loc[data_sample['bear'] == 'Paddington', 'fictional'] = 1
-    data_sample.loc[data_sample['bear'] == 'Baloo', 'fictional'] = 1
-    data_sample.loc[data_sample['bear'] == 'Blossom', 'fictional'] = 1
+    data_sample["fictional"] = 0
+    data_sample.loc[data_sample["bear"] == "Winnie", "fictional"] = 1
+    data_sample.loc[data_sample["bear"] == "Paddington", "fictional"] = 1
+    data_sample.loc[data_sample["bear"] == "Baloo", "fictional"] = 1
+    data_sample.loc[data_sample["bear"] == "Blossom", "fictional"] = 1
 
     return data_sample
 
@@ -64,13 +61,13 @@ def data_small():
     create small dataset
     """
     data_small = pd.DataFrame(index=range(10))
-    data_small['group1'] = 0
-    data_small.loc[0:4, 'group1'] = 1
-    data_small['group2'] = 0
-    data_small.loc[2:7, 'group2'] = 1
-    data_small['group3'] = 0
-    data_small.loc[1:2, 'group3'] = 1
-    data_small.loc[3:7, 'group3'] = 2
+    data_small["group1"] = 0
+    data_small.loc[0:4, "group1"] = 1
+    data_small["group2"] = 0
+    data_small.loc[2:7, "group2"] = 1
+    data_small["group3"] = 0
+    data_small.loc[1:2, "group3"] = 1
+    data_small.loc[3:7, "group3"] = 2
 
     return data_small
 
@@ -81,29 +78,28 @@ def data_groups(n=20):
     create another dataset
     """
     data_groups = pd.DataFrame(index=range(n))
-    data_groups['group'] = 'group1'
-    data_groups.loc[2:6, 'group'] = 'group2'
-    data_groups.loc[6:12, 'group'] = 'group3'
-    data_groups.loc[12: n, 'group'] = 'group4'
-    data_groups['age'] = range(n)
-    data_groups['weight'] = [x+100 for x in range(n)]
+    data_groups["group"] = "group1"
+    data_groups.loc[2:6, "group"] = "group2"
+    data_groups.loc[6:12, "group"] = "group3"
+    data_groups.loc[12:n, "group"] = "group4"
+    data_groups["age"] = range(n)
+    data_groups["weight"] = [x + 100 for x in range(n)]
 
     return data_groups
 
 
 @pytest.fixture(scope="function")
-def data_categorical(n_cat=100, n_obs_per_cat=1000,
-                     n_col=10):
+def data_categorical(n_cat=100, n_obs_per_cat=1000, n_col=10):
     """
     create a dataframe with many categories of many levels
     """
     # dataframe with many categories of many levels
     # generate integers to represent data
-    data = np.arange(n_cat*n_obs_per_cat*n_col)
+    data = np.arange(n_cat * n_obs_per_cat * n_col)
     # use modulus to create categories - unique for each column
-    data = np.mod(data, n_cat*n_col)
+    data = np.mod(data, n_cat * n_col)
     # reshape intro a matrix
-    data = data.reshape(n_cat*n_obs_per_cat, n_col)
+    data = data.reshape(n_cat * n_obs_per_cat, n_col)
     return pd.DataFrame(data)
 
 
@@ -115,11 +111,11 @@ def data_mixed(n=20):
     data_mixed = pd.DataFrame(index=range(n))
     np.random.seed(seed)
 
-    data_mixed['string data'] = 'a'
+    data_mixed["string data"] = "a"
 
     mu, sigma = 50, 5
-    data_mixed['mixed numeric data'] = np.random.normal(mu, sigma, n)
-    data_mixed.loc[1, 'mixed numeric data'] = 'could not measure'
+    data_mixed["mixed numeric data"] = np.random.normal(mu, sigma, n)
+    data_mixed.loc[1, "mixed numeric data"] = "could not measure"
     return data_mixed
 
 
@@ -137,46 +133,38 @@ class TestTableOne(object):
     Tests for TableOne
     """
 
-    def test_examples_used_in_the_readme_run_without_raising_error_pn(
-            self, data_pn):
-
-        columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
-        categorical = ['ICU', 'death']
-        groupby = ['death']
-        nonnormal = ['Age']
-        TableOne(data_pn, columns=columns,
-                 categorical=categorical, groupby=groupby,
-                 nonnormal=nonnormal, pval=False)
+    def test_examples_used_in_the_readme_run_without_raising_error_pn(self, data_pn):
+        columns = ["Age", "SysABP", "Height", "Weight", "ICU", "death"]
+        categorical = ["ICU", "death"]
+        groupby = ["death"]
+        nonnormal = ["Age"]
+        TableOne(data_pn, columns=columns, categorical=categorical, groupby=groupby, nonnormal=nonnormal, pval=False)
 
     def test_robust_to_duplicates_in_input_df_index(self):
+        d_control = pd.DataFrame(data={"group": [0, 0, 0, 0, 0, 0, 0], "value": [3, 4, 4, 4, 4, 4, 5]})
 
-        d_control = pd.DataFrame(data={'group': [0, 0, 0, 0, 0, 0, 0],
-                                 'value': [3, 4, 4, 4, 4, 4, 5]})
-
-        d_case = pd.DataFrame(data={'group': [1, 1, 1], 'value': [1, 2, 3]})
+        d_case = pd.DataFrame(data={"group": [1, 1, 1], "value": [1, 2, 3]})
         d = pd.concat([d_case, d_control])
 
         with pytest.raises(InputError):
-            TableOne(d, ['value'], groupby='group', pval=True)
+            TableOne(d, ["value"], groupby="group", pval=True)
 
         d_idx_reset = pd.concat([d_case, d_control], ignore_index=True)
-        t2 = TableOne(d_idx_reset, ['value'], groupby='group', pval=True)
+        t2 = TableOne(d_idx_reset, ["value"], groupby="group", pval=True)
 
         header = "Grouped by group"
         mean_std_0 = t2.tableone[header].at[("value, mean (SD)", ""), "0"]
         mean_std_1 = t2.tableone[header].at[("value, mean (SD)", ""), "1"]
 
-        assert mean_std_0 == '4.0 (0.6)'
-        assert mean_std_1 == '2.0 (1.0)'
+        assert mean_std_0 == "4.0 (0.6)"
+        assert mean_std_1 == "2.0 (1.0)"
 
-    def test_overall_mean_and_std_as_expected_for_cont_variable(
-            self, data_sample):
-
-        columns = ['normal', 'nonnormal', 'height']
+    def test_overall_mean_and_std_as_expected_for_cont_variable(self, data_sample):
+        columns = ["normal", "nonnormal", "height"]
         table = TableOne(data_sample, columns=columns)
 
-        mean = table.cont_describe.loc['normal']['mean']['Overall']
-        std = table.cont_describe.loc['normal']['std']['Overall']
+        mean = table.cont_describe.loc["normal"]["mean"]["Overall"]
+        std = table.cont_describe.loc["normal"]["std"]["Overall"]
 
         print(data_sample.mean(numeric_only=True))
         print(data_sample.std(numeric_only=True))
@@ -184,45 +172,39 @@ class TestTableOne(object):
         assert abs(mean - data_sample.normal.mean()) <= 0.02
         assert abs(std - data_sample.normal.std()) <= 0.02
 
-    def test_overall_n_and_percent_as_expected_for_binary_cat_variable(
-            self, data_sample):
+    def test_overall_n_and_percent_as_expected_for_binary_cat_variable(self, data_sample):
+        categorical = ["likesmarmalade"]
+        table = TableOne(data_sample, columns=categorical, categorical=categorical)
 
-        categorical = ['likesmarmalade']
-        table = TableOne(data_sample, columns=categorical,
-                         categorical=categorical)
+        lm = table.cat_describe.loc["likesmarmalade"]
 
-        lm = table.cat_describe.loc['likesmarmalade']
-
-        notlikefreq = float(lm.loc['0', 'freq'].values[0])
-        notlikepercent = float(lm.loc['0', 'percent'].values[0])
-        likefreq = float(lm.loc['1', 'freq'].values[0])
-        likepercent = float(lm.loc['1', 'percent'].values[0])
+        notlikefreq = float(lm.loc["0", "freq"].values[0])
+        notlikepercent = float(lm.loc["0", "percent"].values[0])
+        likefreq = float(lm.loc["1", "freq"].values[0])
+        likepercent = float(lm.loc["1", "percent"].values[0])
 
         assert notlikefreq + likefreq == 10000
         assert abs(100 - notlikepercent - likepercent) <= 0.02
         assert notlikefreq == 8977
         assert likefreq == 1023
 
-    def test_overall_n_and_percent_for_binary_cat_var_with_nan(
-            self, data_sample):
+    def test_overall_n_and_percent_for_binary_cat_var_with_nan(self, data_sample):
         """
         Ignore NaNs when counting the number of values and the overall
         percentage
         """
-        categorical = ['likeshoney']
-        table = TableOne(data_sample, columns=categorical,
-                         categorical=categorical)
+        categorical = ["likeshoney"]
+        table = TableOne(data_sample, columns=categorical, categorical=categorical)
 
-        lh = table.cat_describe.loc['likeshoney']
+        lh = table.cat_describe.loc["likeshoney"]
 
-        likefreq = float(lh.loc['1.0', 'freq'].values[0])
-        likepercent = float(lh.loc['1.0', 'percent'].values[0])
+        likefreq = float(lh.loc["1.0", "freq"].values[0])
+        likepercent = float(lh.loc["1.0", "percent"].values[0])
 
         assert likefreq == 5993
-        assert abs(100-likepercent) <= 0.01
+        assert abs(100 - likepercent) <= 0.01
 
-    def test_with_data_as_only_input_argument(
-            self, data_groups):
+    def test_with_data_as_only_input_argument(self, data_groups):
         """
         Test with a simple dataset that a table generated with no pre-specified
         columns returns the same results as a table generated with specified
@@ -230,17 +212,14 @@ class TestTableOne(object):
         """
         table_no_args = TableOne(data_groups)
 
-        columns = ['group', 'age', 'weight']
-        categorical = ['group']
-        table_with_args = TableOne(data_groups, columns=columns,
-                                   categorical=categorical)
+        columns = ["group", "age", "weight"]
+        categorical = ["group"]
+        table_with_args = TableOne(data_groups, columns=columns, categorical=categorical)
 
         assert table_no_args._columns == table_with_args._columns
         assert table_no_args._categorical == table_with_args._categorical
-        assert (table_no_args.tableone.columns ==
-                table_with_args.tableone.columns).all()
-        assert (table_no_args.tableone['Overall'].values ==
-                table_with_args.tableone['Overall'].values).all()
+        assert (table_no_args.tableone.columns == table_with_args.tableone.columns).all()
+        assert (table_no_args.tableone["Overall"].values == table_with_args.tableone["Overall"].values).all()
         assert (table_no_args.tableone == table_with_args.tableone).all().all()
 
     def test_fisher_exact_for_small_cell_count(self, data_small):
@@ -248,43 +227,45 @@ class TestTableOne(object):
         Ensure that the package runs Fisher exact if cell counts are <=5
         and it is a 2x2
         """
-        categorical = ['group1', 'group3']
-        table = TableOne(data_small, categorical=categorical,
-                         groupby='group2', pval=True)
+        categorical = ["group1", "group3"]
+        table = TableOne(data_small, categorical=categorical, groupby="group2", pval=True)
 
         # group2 should be tested because it's a 2x2
         # group3 is a 2x3 so should not be tested
-        assert (table._htest_table.loc['group1', 'Test'] == "Fisher's exact")
-        assert (table._htest_table.loc['group3', 'Test'] ==
-                'Chi-squared (warning: expected count < 5)')
+        assert table._htest_table.loc["group1", "Test"] == "Fisher's exact"
+        assert table._htest_table.loc["group3", "Test"] == "Chi-squared (warning: expected count < 5)"
 
     def test_sequence_of_cont_table(self, data_groups):
         """
         Ensure that the columns align with the values
         """
-        columns = ['age', 'weight']
+        columns = ["age", "weight"]
         categorical = []
-        groupby = 'group'
-        t = TableOne(data_groups, columns=columns,
-                     categorical=categorical, groupby=groupby,
-                     missing=False, decimals=2, label_suffix=False,
-                     overall=False)
+        groupby = "group"
+        t = TableOne(
+            data_groups,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            missing=False,
+            decimals=2,
+            label_suffix=False,
+            overall=False,
+        )
 
         # n and weight rows are already ordered, so sorting should
         # not change the order
-        assert (t.tableone.loc['n'].values[0].astype(float) ==
-                sorted(t.tableone.loc['n'].values[0].astype(float))).any()
-        assert (t.tableone.loc['age'].values[0] ==
-                ['0.50 (0.71)', '3.50 (1.29)', '8.50 (1.87)',
-                 '15.50 (2.45)']).any()
+        assert (
+            t.tableone.loc["n"].values[0].astype(float) == sorted(t.tableone.loc["n"].values[0].astype(float))
+        ).any()
+        assert (t.tableone.loc["age"].values[0] == ["0.50 (0.71)", "3.50 (1.29)", "8.50 (1.87)", "15.50 (2.45)"]).any()
 
     def test_categorical_cell_count(self, data_categorical):
         """
         Check the categorical cell counts are correct
         """
         categorical = list(np.arange(10))
-        table = TableOne(data_categorical, columns=categorical,
-                         categorical=categorical)
+        table = TableOne(data_categorical, columns=categorical, categorical=categorical)
         df = table.cat_describe
         # drop 'overall' level of column index
         df.columns = df.columns.droplevel(level=1)
@@ -310,26 +291,85 @@ class TestTableOne(object):
         t3 = hartigan_diptest(dist_3_peak)
         assert t3 < 0.05
 
+    def test_limit_of_categorical_data_pn_missing_value_on_separate_row(self, data_pn):
+        """
+        Tests the `limit` keyword arg, which limits the number of categories
+        presented
+        """
+        # 6 categories of age based on decade
+        data_pn["age_group"] = data_pn["Age"].map(lambda x: int(x / 10))
+
+        # limit
+        columns = ["age_group", "Age", "SysABP", "Height", "Weight", "ICU", "death"]
+        categorical = ["age_group", "ICU", "death"]
+
+        # test it limits to 3
+        table = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            limit=3,
+            label_suffix=False,
+            missing_value_on_separate_row=True,
+        )
+        assert table.tableone.loc["age_group", :].shape[0] == 3
+
+        # test other categories are not affected if limit > num categories
+        # +1 for the missing count row
+        assert table.tableone.loc["death", :].shape[0] == 2 + 1
+
     def test_limit_of_categorical_data_pn(self, data_pn):
         """
         Tests the `limit` keyword arg, which limits the number of categories
         presented
         """
         # 6 categories of age based on decade
-        data_pn['age_group'] = data_pn['Age'].map(lambda x: int(x/10))
+        data_pn["age_group"] = data_pn["Age"].map(lambda x: int(x / 10))
 
         # limit
-        columns = ['age_group', 'Age', 'SysABP', 'Height', 'Weight', 'ICU',
-                   'death']
-        categorical = ['age_group', 'ICU', 'death']
+        columns = ["age_group", "Age", "SysABP", "Height", "Weight", "ICU", "death"]
+        categorical = ["age_group", "ICU", "death"]
 
         # test it limits to 3
-        table = TableOne(data_pn, columns=columns, categorical=categorical,
-                         limit=3, label_suffix=False)
-        assert table.tableone.loc['age_group', :].shape[0] == 3
+        table = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            limit=3,
+            label_suffix=False,
+            missing_value_on_separate_row=False,
+        )
+        assert table.tableone.loc["age_group", :].shape[0] == 3
 
         # test other categories are not affected if limit > num categories
-        assert table.tableone.loc['death', :].shape[0] == 2
+        assert table.tableone.loc["death", :].shape[0] == 2
+
+    def test_limit_of_categorical_data_pn_dedicated_missing_row(self, data_pn):
+        """
+        Tests the `limit` keyword arg, which limits the number of categories
+        presented
+        """
+        # 6 categories of age based on decade
+        data_pn["age_group"] = data_pn["Age"].map(lambda x: int(x / 10))
+
+        # limit
+        columns = ["age_group", "Age", "SysABP", "Height", "Weight", "ICU", "death"]
+        categorical = ["age_group", "ICU", "death"]
+
+        # test it limits to 3
+        table = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            limit=3,
+            label_suffix=False,
+            missing_value_on_separate_row=True,
+        )
+        assert table.tableone.loc["age_group", :].shape[0] == 3
+
+        # test other categories are not affected if limit > num categories
+        # +1 because it has the extra row to separately display the missing count
+        assert table.tableone.loc["death", :].shape[0] == 2 + 1
 
     def test_input_data_not_modified(self, data_groups):
         """
@@ -343,75 +383,78 @@ class TestTableOne(object):
         # no input arguments
         df_no_args = data_groups.copy()
         TableOne(df_no_args)
-        assert (df_no_args['group'] == df_orig['group']).all()
+        assert (df_no_args["group"] == df_orig["group"]).all()
 
         # groupby
         df_groupby = data_groups.copy()
-        TableOne(df_groupby,
-                 columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'])
-        assert (df_groupby['group'] == df_orig['group']).all()
-        assert (df_groupby['age'] == df_orig['age']).all()
-        assert (df_groupby['weight'] == df_orig['weight']).all()
+        TableOne(df_groupby, columns=["group", "age", "weight"], categorical=["group"], groupby=["group"])
+        assert (df_groupby["group"] == df_orig["group"]).all()
+        assert (df_groupby["age"] == df_orig["age"]).all()
+        assert (df_groupby["weight"] == df_orig["weight"]).all()
 
         # sorted
         df_sorted = data_groups.copy()
-        TableOne(df_sorted, columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
-                 sort=True)
-        assert (df_sorted['group'] == df_orig['group']).all()
-        assert (df_groupby['age'] == df_orig['age']).all()
-        assert (df_groupby['weight'] == df_orig['weight']).all()
+        TableOne(df_sorted, columns=["group", "age", "weight"], categorical=["group"], groupby=["group"], sort=True)
+        assert (df_sorted["group"] == df_orig["group"]).all()
+        assert (df_groupby["age"] == df_orig["age"]).all()
+        assert (df_groupby["weight"] == df_orig["weight"]).all()
 
         # pval
         df_pval = data_groups.copy()
-        TableOne(df_pval, columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
-                 sort=True, pval=True)
-        assert (df_pval['group'] == df_orig['group']).all()
-        assert (df_groupby['age'] == df_orig['age']).all()
-        assert (df_groupby['weight'] == df_orig['weight']).all()
+        TableOne(
+            df_pval, columns=["group", "age", "weight"], categorical=["group"], groupby=["group"], sort=True, pval=True
+        )
+        assert (df_pval["group"] == df_orig["group"]).all()
+        assert (df_groupby["age"] == df_orig["age"]).all()
+        assert (df_groupby["weight"] == df_orig["weight"]).all()
 
         # pval_adjust
         df_pval_adjust = data_groups.copy()
-        TableOne(df_pval_adjust,
-                 columns=['group', 'age', 'weight'],
-                 categorical=['group'],
-                 groupby=['group'], sort=True, pval=True,
-                 pval_adjust='bonferroni')
-        assert (df_pval_adjust['group'] == df_orig['group']).all()
-        assert (df_groupby['age'] == df_orig['age']).all()
-        assert (df_groupby['weight'] == df_orig['weight']).all()
+        TableOne(
+            df_pval_adjust,
+            columns=["group", "age", "weight"],
+            categorical=["group"],
+            groupby=["group"],
+            sort=True,
+            pval=True,
+            pval_adjust="bonferroni",
+        )
+        assert (df_pval_adjust["group"] == df_orig["group"]).all()
+        assert (df_groupby["age"] == df_orig["age"]).all()
+        assert (df_groupby["weight"] == df_orig["weight"]).all()
 
         # labels
         df_labels = data_groups.copy()
-        TableOne(df_labels,
-                 columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
-                 rename={'age': 'age, years'})
-        assert (df_labels['group'] == df_orig['group']).all()
-        assert (df_groupby['age'] == df_orig['age']).all()
-        assert (df_groupby['weight'] == df_orig['weight']).all()
+        TableOne(
+            df_labels,
+            columns=["group", "age", "weight"],
+            categorical=["group"],
+            groupby=["group"],
+            rename={"age": "age, years"},
+        )
+        assert (df_labels["group"] == df_orig["group"]).all()
+        assert (df_groupby["age"] == df_orig["age"]).all()
+        assert (df_groupby["weight"] == df_orig["weight"]).all()
 
         # limit
         df_limit = data_groups.copy()
-        TableOne(df_limit,
-                 columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
-                 limit=2)
-        assert (df_limit['group'] == df_orig['group']).all()
-        assert (df_groupby['age'] == df_orig['age']).all()
-        assert (df_groupby['weight'] == df_orig['weight']).all()
+        TableOne(df_limit, columns=["group", "age", "weight"], categorical=["group"], groupby=["group"], limit=2)
+        assert (df_limit["group"] == df_orig["group"]).all()
+        assert (df_groupby["age"] == df_orig["age"]).all()
+        assert (df_groupby["weight"] == df_orig["weight"]).all()
 
         # nonnormal
         df_nonnormal = data_groups.copy()
-        TableOne(df_nonnormal,
-                 columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
-                 nonnormal=['age'])
-        assert (df_nonnormal['group'] == df_orig['group']).all()
-        assert (df_groupby['age'] == df_orig['age']).all()
-        assert (df_groupby['weight'] == df_orig['weight']).all()
+        TableOne(
+            df_nonnormal,
+            columns=["group", "age", "weight"],
+            categorical=["group"],
+            groupby=["group"],
+            nonnormal=["age"],
+        )
+        assert (df_nonnormal["group"] == df_orig["group"]).all()
+        assert (df_groupby["age"] == df_orig["age"]).all()
+        assert (df_groupby["weight"] == df_orig["weight"]).all()
 
         # warnings.simplefilter("default")
 
@@ -421,64 +464,60 @@ class TestTableOne(object):
         """
         df = data_pn.copy()
 
-        columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU']
-        groupby = 'ICU'
+        columns = ["Age", "SysABP", "Height", "Weight", "ICU"]
+        groupby = "ICU"
         group_levels = df[groupby].unique()
 
         # collect the possible column names
         table = TableOne(df, columns=columns, groupby=groupby, pval=True)
         tableone_columns = list(table.tableone.columns.levels[1])
 
-        table = TableOne(df, columns=columns, groupby=groupby, pval=True,
-                         pval_adjust='b')
-        tableone_columns = (tableone_columns +
-                            list(table.tableone.columns.levels[1]))
+        table = TableOne(df, columns=columns, groupby=groupby, pval=True, pval_adjust="b")
+        tableone_columns = tableone_columns + list(table.tableone.columns.levels[1])
         tableone_columns = np.unique(tableone_columns)
-        tableone_columns = [c for c in tableone_columns
-                            if c not in group_levels]
+        tableone_columns = [c for c in tableone_columns if c not in group_levels]
 
         for c in tableone_columns:
             # for each output column name in tableone, try them as a group
-            df.loc[0:20, 'ICU'] = c
-            if 'adjust' in c:
-                pval_adjust = 'b'
+            df.loc[0:20, "ICU"] = c
+            if "adjust" in c:
+                pval_adjust = "b"
             else:
                 pval_adjust = None
 
             with pytest.raises(InputError):
-                table = TableOne(df, columns=columns, groupby=groupby,
-                                 pval=True, pval_adjust=pval_adjust)
+                table = TableOne(df, columns=columns, groupby=groupby, pval=True, pval_adjust=pval_adjust)
 
     def test_label_dictionary_input_pn(self, data_pn):
         """
         Test columns and rows are relabelled with the label argument
         """
         df = data_pn.copy()
-        columns = ['Age', 'ICU', 'death']
-        categorical = ['death', 'ICU']
-        groupby = 'death'
+        columns = ["Age", "ICU", "death"]
+        categorical = ["death", "ICU"]
+        groupby = "death"
 
-        labels = {'death': 'mortality', 'Age': 'Age, years',
-                  'ICU': 'Intensive Care Unit'}
+        labels = {"death": "mortality", "Age": "Age, years", "ICU": "Intensive Care Unit"}
 
-        table = TableOne(df, columns=columns, categorical=categorical,
-                         groupby=groupby, rename=labels, label_suffix=False)
+        table = TableOne(
+            df, columns=columns, categorical=categorical, groupby=groupby, rename=labels, label_suffix=False
+        )
 
         # check the header column is updated (groupby variable)
-        assert table.tableone.columns.levels[0][0] == 'Grouped by mortality'
+        assert table.tableone.columns.levels[0][0] == "Grouped by mortality"
 
         # check the categorical rows are updated
-        assert 'Intensive Care Unit' in table.tableone.index.levels[0]
+        assert "Intensive Care Unit" in table.tableone.index.levels[0]
 
         # check the continuous rows are updated
-        assert 'Age, years' in table.tableone.index.levels[0]
+        assert "Age, years" in table.tableone.index.levels[0]
 
     def test_tableone_row_sort_pn(self, data_pn):
         """
         Test sort functionality of TableOne
         """
         df = data_pn.copy()
-        columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
+        columns = ["Age", "SysABP", "Height", "Weight", "ICU", "death"]
         table = TableOne(df, columns=columns, label_suffix=False)
 
         # a call to .index.levels[0] automatically sorts the levels
@@ -488,13 +527,13 @@ class TestTableOne(object):
         # default should not sort
         for i, c in enumerate(columns):
             # i+1 because we skip the first row, 'n'
-            assert tableone_rows[i+1] == c
+            assert tableone_rows[i + 1] == c
 
         table = TableOne(df, columns=columns, sort=True, label_suffix=False)
         tableone_rows = pd.unique([x[0] for x in table.tableone.index.values])
         for i, c in enumerate(sorted(columns, key=lambda s: s.lower())):
             # i+1 because we skip the first row, 'n'
-            assert tableone_rows[i+1] == c
+            assert tableone_rows[i + 1] == c
 
     def test_string_data_as_continuous_error(self, data_mixed):
         """
@@ -512,67 +551,64 @@ class TestTableOne(object):
         Test output columns in TableOne are always in the same order
         """
         df = data_pn.copy()
-        columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
-        groupby = ['death']
+        columns = ["Age", "SysABP", "Height", "Weight", "ICU", "death"]
+        groupby = ["death"]
 
-        table = TableOne(df, columns=columns, groupby=groupby, pval=True,
-                         htest_name=True, overall=False)
+        table = TableOne(df, columns=columns, groupby=groupby, pval=True, htest_name=True, overall=False)
 
-        assert table.tableone.columns.levels[1][0] == 'Missing'
-        assert table.tableone.columns.levels[1][-1] == 'Test'
-        assert table.tableone.columns.levels[1][-2] == 'P-Value'
+        assert table.tableone.columns.levels[1][0] == "Missing"
+        assert table.tableone.columns.levels[1][-1] == "Test"
+        assert table.tableone.columns.levels[1][-2] == "P-Value"
 
-        df.loc[df['death'] == 0, 'death'] = 2
+        df.loc[df["death"] == 0, "death"] = 2
 
         # without overall column
-        table = TableOne(df, columns=columns, groupby=groupby, pval=True,
-                         pval_adjust='bonferroni', htest_name=True,
-                         overall=False)
+        table = TableOne(
+            df, columns=columns, groupby=groupby, pval=True, pval_adjust="bonferroni", htest_name=True, overall=False
+        )
 
-        assert table.tableone.columns.levels[1][0] == 'Missing'
-        assert table.tableone.columns.levels[1][-1] == 'Test'
-        assert table.tableone.columns.levels[1][-2] == 'P-Value (adjusted)'
+        assert table.tableone.columns.levels[1][0] == "Missing"
+        assert table.tableone.columns.levels[1][-1] == "Test"
+        assert table.tableone.columns.levels[1][-2] == "P-Value (adjusted)"
 
         # with overall column
-        table = TableOne(df, columns=columns, groupby=groupby, pval=True,
-                         pval_adjust='bonferroni', htest_name=True,
-                         overall=True)
+        table = TableOne(
+            df, columns=columns, groupby=groupby, pval=True, pval_adjust="bonferroni", htest_name=True, overall=True
+        )
 
-        assert table.tableone.columns.levels[1][0] == 'Missing'
-        assert table.tableone.columns.levels[1][1] == 'Overall'
-        assert table.tableone.columns.levels[1][-1] == 'Test'
-        assert table.tableone.columns.levels[1][-2] == 'P-Value (adjusted)'
+        assert table.tableone.columns.levels[1][0] == "Missing"
+        assert table.tableone.columns.levels[1][1] == "Overall"
+        assert table.tableone.columns.levels[1][-1] == "Test"
+        assert table.tableone.columns.levels[1][-2] == "P-Value (adjusted)"
 
     def test_check_null_counts_are_correct_pn(self, data_pn):
         """
         Test that the isnull column is correctly reporting number of nulls
         """
-        columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
-        categorical = ['ICU', 'death']
-        groupby = ['death']
+        columns = ["Age", "SysABP", "Height", "Weight", "ICU", "death"]
+        categorical = ["ICU", "death"]
+        groupby = ["death"]
 
         # test when not grouping
-        table = TableOne(data_pn, columns=columns,
-                         categorical=categorical)
+        table = TableOne(data_pn, columns=columns, categorical=categorical)
 
         # get isnull column only
         isnull = table.tableone.iloc[:, 0]
         for i, v in enumerate(isnull):
             # skip empty rows by checking value is not a string
-            if 'float' in str(type(v)):
+            if "float" in str(type(v)):
                 # check each null count is correct
                 col = isnull.index[i][0]
                 assert data_pn[col].isnull().sum() == v
 
         # test when grouping by a variable
-        grouped_table = TableOne(data_pn, columns=columns,
-                                 categorical=categorical, groupby=groupby)
+        grouped_table = TableOne(data_pn, columns=columns, categorical=categorical, groupby=groupby)
 
         # get isnull column only
         isnull = grouped_table.tableone.iloc[:, 0]
         for i, v in enumerate(isnull):
             # skip empty rows by checking value is not a string
-            if 'float' in str(type(v)):
+            if "float" in str(type(v)):
                 # check each null count is correct
                 col = isnull.index[i][0]
                 assert data_pn[col].isnull().sum() == v
@@ -606,167 +642,332 @@ class TestTableOne(object):
         of decimal places for all summary statistics (e.g. mean and standard
         deviation).
         """
-        columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
-        categorical = ['ICU', 'death']
-        groupby = ['death']
-        nonnormal = ['Age']
+        columns = ["Age", "SysABP", "Height", "Weight", "ICU", "death"]
+        categorical = ["ICU", "death"]
+        groupby = ["death"]
+        nonnormal = ["Age"]
 
         # no decimals argument
         # expected result is to default to 1
-        t_no_arg = TableOne(data_pn, columns=columns,
-                            categorical=categorical, groupby=groupby,
-                            nonnormal=nonnormal, pval=False,
-                            label_suffix=False)
+        t_no_arg = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            label_suffix=False,
+        )
 
-        t_no_arg_group0 = t_no_arg.tableone['Grouped by death'].loc["Weight",
-                                                                    "0"].values
-        t_no_arg_group0_expected = np.array(['83.0 (23.6)'])
+        t_no_arg_group0 = t_no_arg.tableone["Grouped by death"].loc["Weight", "0"].values
+        t_no_arg_group0_expected = np.array(["83.0 (23.6)"])
 
-        t_no_arg_group1 = t_no_arg.tableone['Grouped by death'].loc["Weight",
-                                                                    "1"].values
-        t_no_arg_group1_expected = np.array(['82.3 (25.4)'])
+        t_no_arg_group1 = t_no_arg.tableone["Grouped by death"].loc["Weight", "1"].values
+        t_no_arg_group1_expected = np.array(["82.3 (25.4)"])
 
         assert all(t_no_arg_group0 == t_no_arg_group0_expected)
         assert all(t_no_arg_group1 == t_no_arg_group1_expected)
 
         # decimals = 1
-        t1_decimal = TableOne(data_pn, columns=columns,
-                              categorical=categorical, groupby=groupby,
-                              nonnormal=nonnormal, pval=False, decimals=1,
-                              label_suffix=False)
+        t1_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals=1,
+            label_suffix=False,
+        )
 
-        t1_group0 = t1_decimal.tableone['Grouped by death'].loc["Weight",
-                                                                "0"].values
-        t1_group0_expected = np.array(['83.0 (23.6)'])
+        t1_group0 = t1_decimal.tableone["Grouped by death"].loc["Weight", "0"].values
+        t1_group0_expected = np.array(["83.0 (23.6)"])
 
-        t1_group1 = t1_decimal.tableone['Grouped by death'].loc["Weight",
-                                                                "1"].values
-        t1_group1_expected = np.array(['82.3 (25.4)'])
+        t1_group1 = t1_decimal.tableone["Grouped by death"].loc["Weight", "1"].values
+        t1_group1_expected = np.array(["82.3 (25.4)"])
 
         assert all(t1_group0 == t1_group0_expected)
         assert all(t1_group1 == t1_group1_expected)
 
         # decimals = 2
-        t2_decimal = TableOne(data_pn, columns=columns,
-                              categorical=categorical, groupby=groupby,
-                              nonnormal=nonnormal, pval=False, decimals=2,
-                              label_suffix=False)
+        t2_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals=2,
+            label_suffix=False,
+        )
 
-        t2_group0 = t2_decimal.tableone['Grouped by death'].loc["Weight",
-                                                                "0"].values
-        t2_group0_expected = np.array(['83.04 (23.58)'])
+        t2_group0 = t2_decimal.tableone["Grouped by death"].loc["Weight", "0"].values
+        t2_group0_expected = np.array(["83.04 (23.58)"])
 
-        t2_group1 = t2_decimal.tableone['Grouped by death'].loc["Weight",
-                                                                "1"].values
-        t2_group1_expected = np.array(['82.29 (25.40)'])
+        t2_group1 = t2_decimal.tableone["Grouped by death"].loc["Weight", "1"].values
+        t2_group1_expected = np.array(["82.29 (25.40)"])
 
         assert all(t2_group0 == t2_group0_expected)
         assert all(t2_group1 == t2_group1_expected)
 
         # decimals = {"Age": 0, "Weight":3}
-        t3_decimal = TableOne(data_pn, columns=columns,
-                              categorical=categorical, groupby=groupby,
-                              nonnormal=nonnormal, pval=False,
-                              decimals={"Age": 0, "Weight": 3},
-                              label_suffix=False)
+        t3_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals={"Age": 0, "Weight": 3},
+            label_suffix=False,
+        )
 
-        t3_group0 = t3_decimal.tableone['Grouped by death'].loc["Weight",
-                                                                "0"].values
-        t3_group0_expected = np.array(['83.041 (23.581)'])
+        t3_group0 = t3_decimal.tableone["Grouped by death"].loc["Weight", "0"].values
+        t3_group0_expected = np.array(["83.041 (23.581)"])
 
-        t3_group1 = t3_decimal.tableone['Grouped by death'].loc["Weight",
-                                                                "1"].values
-        t3_group1_expected = np.array(['82.286 (25.396)'])
+        t3_group1 = t3_decimal.tableone["Grouped by death"].loc["Weight", "1"].values
+        t3_group1_expected = np.array(["82.286 (25.396)"])
 
         assert all(t3_group0 == t3_group0_expected)
         assert all(t3_group1 == t3_group1_expected)
 
-    def test_the_decimals_argument_for_categorical_variables(self, data_pn):
+    def test_the_decimals_argument_for_categorical_variables_missing_value_on_separate_row(self, data_pn):
         """
         For categorical variables, the decimals argument should set the number
         of decimal places for the percent only.
         """
-        columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
-        categorical = ['ICU', 'death']
-        groupby = ['death']
-        nonnormal = ['Age']
+        columns = ["Age", "SysABP", "Height", "Weight", "ICU", "death"]
+        categorical = ["ICU", "death"]
+        groupby = ["death"]
+        nonnormal = ["Age"]
 
         # decimals = 1
-        t1_decimal = TableOne(data_pn, columns=columns,
-                              categorical=categorical, groupby=groupby,
-                              nonnormal=nonnormal, pval=False, decimals=1,
-                              label_suffix=False)
+        t1_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals=1,
+            label_suffix=False,
+            missing_value_on_separate_row=True,
+        )
 
-        t1_group0 = t1_decimal.tableone['Grouped by death'].loc["ICU",
-                                                                "0"].values
-        t1_group0_expected = np.array(['137 (15.9)', '194 (22.5)',
-                                      '318 (36.8)', '215 (24.9)'])
+        t1_group0 = t1_decimal.tableone["Grouped by death"].loc["ICU", "0"].values
+        t1_group0_expected = np.array(["", "137 (15.9)", "194 (22.5)", "318 (36.8)", "215 (24.9)"])
 
-        t1_group1 = t1_decimal.tableone['Grouped by death'].loc["ICU",
-                                                                "1"].values
-        t1_group1_expected = np.array(['25 (18.4)', '8 (5.9)',
-                                      '62 (45.6)', '41 (30.1)'])
+        t1_group1 = t1_decimal.tableone["Grouped by death"].loc["ICU", "1"].values
+        t1_group1_expected = np.array(["", "25 (18.4)", "8 (5.9)", "62 (45.6)", "41 (30.1)"])
 
         assert all(t1_group0 == t1_group0_expected)
         assert all(t1_group1 == t1_group1_expected)
 
         # decimals = 2
-        t2_decimal = TableOne(data_pn, columns=columns,
-                              categorical=categorical, groupby=groupby,
-                              nonnormal=nonnormal, pval=False, decimals=2,
-                              label_suffix=False)
+        t2_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals=2,
+            label_suffix=False,
+        )
 
-        t2_group0 = t2_decimal.tableone['Grouped by death'].loc["ICU",
-                                                                "0"].values
-        t2_group0_expected = np.array(['137 (15.86)', '194 (22.45)',
-                                      '318 (36.81)', '215 (24.88)'])
+        t2_group0 = t2_decimal.tableone["Grouped by death"].loc["ICU", "0"].values
+        t2_group0_expected = np.array(["", "137 (15.86)", "194 (22.45)", "318 (36.81)", "215 (24.88)"])
 
-        t2_group1 = t2_decimal.tableone['Grouped by death'].loc["ICU",
-                                                                "1"].values
-        t2_group1_expected = np.array(['25 (18.38)', '8 (5.88)',
-                                      '62 (45.59)', '41 (30.15)'])
+        t2_group1 = t2_decimal.tableone["Grouped by death"].loc["ICU", "1"].values
+        t2_group1_expected = np.array(["", "25 (18.38)", "8 (5.88)", "62 (45.59)", "41 (30.15)"])
 
         assert all(t2_group0 == t2_group0_expected)
         assert all(t2_group1 == t2_group1_expected)
 
         # decimals = {"ICU":3}
-        t3_decimal = TableOne(data_pn, columns=columns,
-                              categorical=categorical, groupby=groupby,
-                              nonnormal=nonnormal, pval=False,
-                              decimals={"ICU": 3}, label_suffix=False)
+        t3_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals={"ICU": 3},
+            label_suffix=False,
+            missing_value_on_separate_row=True,
+        )
 
-        t3_group0 = t3_decimal.tableone['Grouped by death'].loc["ICU",
-                                                                "0"].values
-        t3_group0_expected = np.array(['137 (15.856)', '194 (22.454)',
-                                      '318 (36.806)', '215 (24.884)'])
+        t3_group0 = t3_decimal.tableone["Grouped by death"].loc["ICU", "0"].values
+        t3_group0_expected = np.array(["", "137 (15.856)", "194 (22.454)", "318 (36.806)", "215 (24.884)"])
 
-        t3_group1 = t3_decimal.tableone['Grouped by death'].loc["ICU",
-                                                                "1"].values
-        t3_group1_expected = np.array(['25 (18.382)', '8 (5.882)',
-                                      '62 (45.588)', '41 (30.147)'])
+        t3_group1 = t3_decimal.tableone["Grouped by death"].loc["ICU", "1"].values
+        t3_group1_expected = np.array(["", "25 (18.382)", "8 (5.882)", "62 (45.588)", "41 (30.147)"])
 
         assert all(t3_group0 == t3_group0_expected)
         assert all(t3_group1 == t3_group1_expected)
 
         # decimals = {"Age":3}
         # expected result is to default to 1 decimal place
-        t4_decimal = TableOne(data_pn, columns=columns,
-                              categorical=categorical, groupby=groupby,
-                              nonnormal=nonnormal, pval=False,
-                              decimals={"Age": 3}, label_suffix=False)
+        t4_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals={"Age": 3},
+            label_suffix=False,
+            missing_value_on_separate_row=True,
+        )
 
-        t4_group0 = t4_decimal.tableone['Grouped by death'].loc["ICU",
-                                                                "0"].values
-        t4_group0_expected = np.array(['137 (15.9)', '194 (22.5)',
-                                       '318 (36.8)', '215 (24.9)'])
+        t4_group0 = t4_decimal.tableone["Grouped by death"].loc["ICU", "0"].values
+        t4_group0_expected = np.array(["", "137 (15.9)", "194 (22.5)", "318 (36.8)", "215 (24.9)"])
 
-        t4_group1 = t4_decimal.tableone['Grouped by death'].loc["ICU",
-                                                                "1"].values
-        t4_group1_expected = np.array(['25 (18.4)', '8 (5.9)',
-                                       '62 (45.6)', '41 (30.1)'])
+        t4_group1 = t4_decimal.tableone["Grouped by death"].loc["ICU", "1"].values
+        t4_group1_expected = np.array(["", "25 (18.4)", "8 (5.9)", "62 (45.6)", "41 (30.1)"])
 
         assert all(t4_group0 == t4_group0_expected)
         assert all(t4_group1 == t4_group1_expected)
+
+    def test_the_decimals_argument_for_categorical_variables(self, data_pn):
+        """
+        For categorical variables, the decimals argument should set the number
+        of decimal places for the percent only.
+        """
+        columns = ["Age", "SysABP", "Height", "Weight", "ICU", "death"]
+        categorical = ["ICU", "death"]
+        groupby = ["death"]
+        nonnormal = ["Age"]
+
+        # decimals = 1
+        t1_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals=1,
+            label_suffix=False,
+            missing_value_on_separate_row=False,
+        )
+
+        t1_group0 = t1_decimal.tableone["Grouped by death"].loc["ICU", "0"].values
+        t1_group0_expected = np.array(["137 (15.9)", "194 (22.5)", "318 (36.8)", "215 (24.9)"])
+
+        t1_group1 = t1_decimal.tableone["Grouped by death"].loc["ICU", "1"].values
+        t1_group1_expected = np.array(["25 (18.4)", "8 (5.9)", "62 (45.6)", "41 (30.1)"])
+
+        assert all(t1_group0 == t1_group0_expected)
+        assert all(t1_group1 == t1_group1_expected)
+
+        # decimals = 2
+        t2_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals=2,
+            label_suffix=False,
+            missing_value_on_separate_row=False,
+        )
+
+        t2_group0 = t2_decimal.tableone["Grouped by death"].loc["ICU", "0"].values
+        t2_group0_expected = np.array(["137 (15.86)", "194 (22.45)", "318 (36.81)", "215 (24.88)"])
+
+        t2_group1 = t2_decimal.tableone["Grouped by death"].loc["ICU", "1"].values
+        t2_group1_expected = np.array(["25 (18.38)", "8 (5.88)", "62 (45.59)", "41 (30.15)"])
+
+        assert all(t2_group0 == t2_group0_expected)
+        assert all(t2_group1 == t2_group1_expected)
+
+        # decimals = {"ICU":3}
+        t3_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals={"ICU": 3},
+            label_suffix=False,
+            missing_value_on_separate_row=False,
+        )
+
+        t3_group0 = t3_decimal.tableone["Grouped by death"].loc["ICU", "0"].values
+        t3_group0_expected = np.array(["137 (15.856)", "194 (22.454)", "318 (36.806)", "215 (24.884)"])
+
+        t3_group1 = t3_decimal.tableone["Grouped by death"].loc["ICU", "1"].values
+        t3_group1_expected = np.array(["25 (18.382)", "8 (5.882)", "62 (45.588)", "41 (30.147)"])
+
+        assert all(t3_group0 == t3_group0_expected)
+        assert all(t3_group1 == t3_group1_expected)
+
+        # decimals = {"Age":3}
+        # expected result is to default to 1 decimal place
+        t4_decimal = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            pval=False,
+            decimals={"Age": 3},
+            label_suffix=False,
+            missing_value_on_separate_row=False,
+        )
+
+        t4_group0 = t4_decimal.tableone["Grouped by death"].loc["ICU", "0"].values
+        t4_group0_expected = np.array(["137 (15.9)", "194 (22.5)", "318 (36.8)", "215 (24.9)"])
+
+        t4_group1 = t4_decimal.tableone["Grouped by death"].loc["ICU", "1"].values
+        t4_group1_expected = np.array(["25 (18.4)", "8 (5.9)", "62 (45.6)", "41 (30.1)"])
+
+        assert all(t4_group0 == t4_group0_expected)
+        assert all(t4_group1 == t4_group1_expected)
+
+    def test_nan_rows_not_deleted_in_categorical_columns_missing_value_on_separate_row(self):
+        """
+        Test that rows in categorical columns are not deleted if there are null
+        values (issue #79).
+        """
+        # create the dataset
+        fruit = [
+            ["apple", "durian", "pineapple", "banana"],
+            ["pineapple", "orange", "peach", "lemon"],
+            ["lemon", "peach", "lemon", "banana"],
+            ["durian", "apple", "orange", "lemon"],
+            ["banana", "durian", "lemon", "apple"],
+            ["orange", "pineapple", "lemon", "banana"],
+            ["banana", "orange", "apple", "lemon"],
+        ]
+
+        df = pd.DataFrame(fruit)
+        df.columns = ["basket1", "basket2", "basket3", "basket4"]
+
+        # set two of the columns to none
+        df.loc[1:3, "basket2"] = None
+        df.loc[2:4, "basket3"] = None
+
+        # create tableone
+        t1 = TableOne(
+            df,
+            label_suffix=False,
+            categorical=["basket1", "basket2", "basket3", "basket4"],
+            missing_value_on_separate_row=True,
+        )
+
+        assert all(
+            t1.tableone.loc["basket1"].index == [" ", "apple", "banana", "durian", "lemon", "orange", "pineapple"]
+        )
+
+        assert all(t1.tableone.loc["basket2"].index == [" ", "durian", "orange", "pineapple"])
+
+        assert all(t1.tableone.loc["basket3"].index == [" ", "apple", "lemon", "peach", "pineapple"])
+
+        assert all(t1.tableone.loc["basket4"].index == [" ", "apple", "banana", "lemon"])
 
     def test_nan_rows_not_deleted_in_categorical_columns(self):
         """
@@ -774,69 +975,106 @@ class TestTableOne(object):
         values (issue #79).
         """
         # create the dataset
-        fruit = [['apple', 'durian', 'pineapple', 'banana'],
-                 ['pineapple', 'orange', 'peach', 'lemon'],
-                 ['lemon', 'peach', 'lemon', 'banana'],
-                 ['durian', 'apple', 'orange', 'lemon'],
-                 ['banana', 'durian', 'lemon', 'apple'],
-                 ['orange', 'pineapple', 'lemon', 'banana'],
-                 ['banana', 'orange', 'apple', 'lemon']]
+        fruit = [
+            ["apple", "durian", "pineapple", "banana"],
+            ["pineapple", "orange", "peach", "lemon"],
+            ["lemon", "peach", "lemon", "banana"],
+            ["durian", "apple", "orange", "lemon"],
+            ["banana", "durian", "lemon", "apple"],
+            ["orange", "pineapple", "lemon", "banana"],
+            ["banana", "orange", "apple", "lemon"],
+        ]
 
         df = pd.DataFrame(fruit)
-        df.columns = ['basket1', 'basket2', 'basket3', 'basket4']
+        df.columns = ["basket1", "basket2", "basket3", "basket4"]
 
         # set two of the columns to none
-        df.loc[1:3, 'basket2'] = None
-        df.loc[2:4, 'basket3'] = None
+        df.loc[1:3, "basket2"] = None
+        df.loc[2:4, "basket3"] = None
 
         # create tableone
-        t1 = TableOne(df, label_suffix=False,
-                      categorical=['basket1', 'basket2', 'basket3', 'basket4'])
+        t1 = TableOne(
+            df,
+            label_suffix=False,
+            categorical=["basket1", "basket2", "basket3", "basket4"],
+            missing_value_on_separate_row=False,
+        )
 
-        assert all(t1.tableone.loc['basket1'].index == ['apple', 'banana',
-                                                        'durian', 'lemon',
-                                                        'orange', 'pineapple'])
+        assert all(t1.tableone.loc["basket1"].index == ["apple", "banana", "durian", "lemon", "orange", "pineapple"])
 
-        assert all(t1.tableone.loc['basket2'].index == ['durian', 'orange',
-                                                        'pineapple'])
+        assert all(t1.tableone.loc["basket2"].index == ["durian", "orange", "pineapple"])
 
-        assert all(t1.tableone.loc['basket3'].index == ['apple', 'lemon',
-                                                        'peach', 'pineapple'])
+        assert all(t1.tableone.loc["basket3"].index == ["apple", "lemon", "peach", "pineapple"])
 
-        assert all(t1.tableone.loc['basket4'].index == ['apple', 'banana',
-                                                        'lemon'])
+        assert all(t1.tableone.loc["basket4"].index == ["apple", "banana", "lemon"])
+
+    def test_pval_correction_missing_value_on_separate_row(self):
+        """
+        Test the pval_adjust argument
+        """
+        df = pd.DataFrame(
+            {
+                "numbers": [1, 2, 6, 1, 1, 1],
+                "other": [1, 2, 3, 3, 3, 4],
+                "colors": ["red", "white", "blue", "red", "blue", "blue"],
+                "even": ["yes", "no", "yes", "yes", "no", "yes"],
+            }
+        )
+
+        t1 = TableOne(df, groupby="even", pval=True, pval_adjust="bonferroni", missing_value_on_separate_row=True)
+
+        # check the multiplier is correct (3 = no. of reported values)
+        pvals_expected = {"numbers, mean (SD)": "1.000", "other, mean (SD)": "1.000", "colors, n (%)": "0.669"}
+
+        group = "Grouped by even"
+        col = "P-Value (adjusted)"
+        for k in pvals_expected:
+            values = t1.tableone.loc[k][group][col].values.tolist()
+            if "nan" in values:
+                values.remove("nan")
+            assert values[0] == pvals_expected[k]
+
+        # catch the pval_adjust=True
+        with warnings.catch_warnings(record=False):
+            warnings.simplefilter("ignore", category=UserWarning)
+            TableOne(df, groupby="even", pval=True, pval_adjust=True)
+
+        for k in pvals_expected:
+            values = t1.tableone.loc[k][group][col].values.tolist()
+            if "nan" in values:
+                values.remove("nan")
+            assert values[0] == pvals_expected[k]
 
     def test_pval_correction(self):
         """
         Test the pval_adjust argument
         """
-        df = pd.DataFrame({'numbers': [1, 2, 6, 1, 1, 1],
-                           'other': [1, 2, 3, 3, 3, 4],
-                           'colors': ['red', 'white', 'blue', 'red', 'blue',
-                                      'blue'],
-                           'even': ['yes', 'no', 'yes', 'yes', 'no', 'yes']})
+        df = pd.DataFrame(
+            {
+                "numbers": [1, 2, 6, 1, 1, 1],
+                "other": [1, 2, 3, 3, 3, 4],
+                "colors": ["red", "white", "blue", "red", "blue", "blue"],
+                "even": ["yes", "no", "yes", "yes", "no", "yes"],
+            }
+        )
 
-        t1 = TableOne(df, groupby="even", pval=True, pval_adjust="bonferroni")
+        t1 = TableOne(df, groupby="even", pval=True, pval_adjust="bonferroni", missing_value_on_separate_row=False)
 
         # check the multiplier is correct (3 = no. of reported values)
-        pvals_expected = {'numbers, mean (SD)': '1.000',
-                          'other, mean (SD)': '1.000',
-                          'colors, n (%)': '0.669'}
+        pvals_expected = {"numbers, mean (SD)": "1.000", "other, mean (SD)": "1.000", "colors, n (%)": "0.669"}
 
-        group = 'Grouped by even'
-        col = 'P-Value (adjusted)'
+        group = "Grouped by even"
+        col = "P-Value (adjusted)"
         for k in pvals_expected:
-            assert (t1.tableone.loc[k][group][col].values[0] ==
-                    pvals_expected[k])
+            assert t1.tableone.loc[k][group][col].values[0] == pvals_expected[k]
 
         # catch the pval_adjust=True
         with warnings.catch_warnings(record=False):
-            warnings.simplefilter('ignore', category=UserWarning)
+            warnings.simplefilter("ignore", category=UserWarning)
             TableOne(df, groupby="even", pval=True, pval_adjust=True)
 
         for k in pvals_expected:
-            assert (t1.tableone.loc[k][group][col].values[0] ==
-                    pvals_expected[k])
+            assert t1.tableone.loc[k][group][col].values[0] == pvals_expected[k]
 
     def test_custom_statistical_tests(self):
         """
@@ -853,50 +1091,44 @@ class TestTableOne(object):
         n2 = 300
 
         # Baseline distribution
-        rvs1 = stats.norm.rvs(size=n1, loc=0., scale=1)
-        df1 = pd.DataFrame({'rvs': 'rvs1', 'val': rvs1})
+        rvs1 = stats.norm.rvs(size=n1, loc=0.0, scale=1)
+        df1 = pd.DataFrame({"rvs": "rvs1", "val": rvs1})
 
         # Different to rvs1
         # stats.ks_2samp(rvs1, rvs2)
         # (0.20833333333333334, 5.129279597781977e-05)
         rvs2 = stats.norm.rvs(size=n2, loc=0.5, scale=1.5)
-        df2 = pd.DataFrame({'rvs': 'rvs2', 'val': rvs2})
+        df2 = pd.DataFrame({"rvs": "rvs2", "val": rvs2})
 
         # Similar to rvs1
         # stats.ks_2samp(rvs1, rvs3)
         # (0.10333333333333333, 0.14691437867433876)
         rvs3 = stats.norm.rvs(size=n2, loc=0.01, scale=1.0)
-        df3 = pd.DataFrame({'rvs': 'rvs3', 'val': rvs3})
+        df3 = pd.DataFrame({"rvs": "rvs3", "val": rvs3})
 
         # Identical to rvs1
         # stats.ks_2samp(rvs1, rvs4)
         # (0.07999999999999996, 0.41126949729859719)
         rvs4 = stats.norm.rvs(size=n2, loc=0.0, scale=1.0)
-        df4 = pd.DataFrame({'rvs': 'rvs4', 'val': rvs4})
+        df4 = pd.DataFrame({"rvs": "rvs4", "val": rvs4})
 
         # Table 1 for different distributions
         different = pd.concat([df1, df2], ignore_index=True)
-        t1_diff = TableOne(data=different, columns=["val"], pval=True,
-                           groupby="rvs", htest={"val": func})
+        t1_diff = TableOne(data=different, columns=["val"], pval=True, groupby="rvs", htest={"val": func})
 
-        isclose(t1_diff._htest_table['P-Value'].val,
-                stats.ks_2samp(rvs1, rvs2)[1])
+        isclose(t1_diff._htest_table["P-Value"].val, stats.ks_2samp(rvs1, rvs2)[1])
 
         # Table 1 for similar distributions
         similar = pd.concat([df1, df3], ignore_index=True)
-        t1_similar = TableOne(data=similar, columns=["val"], pval=True,
-                              groupby="rvs", htest={"val": func})
+        t1_similar = TableOne(data=similar, columns=["val"], pval=True, groupby="rvs", htest={"val": func})
 
-        isclose(t1_similar._htest_table['P-Value'].val,
-                stats.ks_2samp(rvs1, rvs3)[1])
+        isclose(t1_similar._htest_table["P-Value"].val, stats.ks_2samp(rvs1, rvs3)[1])
 
         # Table 1 for identical distributions
         identical = pd.concat([df1, df4], ignore_index=True)
-        t1_identical = TableOne(data=identical, columns=["val"], pval=True,
-                                groupby="rvs", htest={"val": func})
+        t1_identical = TableOne(data=identical, columns=["val"], pval=True, groupby="rvs", htest={"val": func})
 
-        isclose(t1_identical._htest_table['P-Value'].val,
-                stats.ks_2samp(rvs1, rvs4)[1])
+        isclose(t1_identical._htest_table["P-Value"].val, stats.ks_2samp(rvs1, rvs4)[1])
 
     def test_compute_standardized_mean_difference_continuous(self, data_pn):
         """
@@ -922,15 +1154,13 @@ class TestTableOne(object):
         sd1 = 5.5
         sd2 = 4.5
 
-        smd, se = t._cont_smd(mean1=mean1, mean2=mean2, sd1=sd1, sd2=sd2,
-                              n1=n1, n2=n2)
+        smd, se = t._cont_smd(mean1=mean1, mean2=mean2, sd1=sd1, sd2=sd2, n1=n1, n2=n2)
 
         assert round(smd, 4) == -0.5970
         assert round(se, 4) == 0.2044
 
         # Test unbiased estimate using Hedges correction (Hedges, 2011)
-        smd, se = t._cont_smd(mean1=mean1, mean2=mean2, sd1=sd1, sd2=sd2,
-                              n1=n1, n2=n2, unbiased=True)
+        smd, se = t._cont_smd(mean1=mean1, mean2=mean2, sd1=sd1, sd2=sd2, n1=n1, n2=n2, unbiased=True)
 
         assert round(smd, 4) == -0.5924
         assert round(se, 4) == 0.2028
@@ -946,28 +1176,51 @@ class TestTableOne(object):
         n2 = len(data2)
         sd1 = np.std(data1)
         sd2 = np.std(data2)
-        smd_summary, se_summary = t._cont_smd(mean1=mean1, mean2=mean2,
-                                              sd1=sd1, sd2=sd2, n1=n1, n2=n2)
+        smd_summary, se_summary = t._cont_smd(mean1=mean1, mean2=mean2, sd1=sd1, sd2=sd2, n1=n1, n2=n2)
 
         assert round(smd_data, 4) == round(smd_summary, 4)
         assert round(se_data, 4) == round(se_summary, 4)
 
         # test with the physionet data
-        categorical = ['ICU', 'MechVent', 'death']
+        categorical = ["ICU", "MechVent", "death"]
         strata = "MechVent"
 
-        t = TableOne(data_pn, categorical=categorical, label_suffix=False,
-                     groupby=strata, pval=True, htest_name=False, smd=True)
+        t = TableOne(
+            data_pn, categorical=categorical, label_suffix=False, groupby=strata, pval=True, htest_name=False, smd=True
+        )
 
         # consistent with R StdDiff() and R tableone
-        exp_smd = {'Age': '-0.129',
-                   'SysABP': '-0.177',
-                   'Height': '-0.073',
-                   'Weight': '0.124',
-                   'LOS': '0.121'}
+        exp_smd = {"Age": "-0.129", "SysABP": "-0.177", "Height": "-0.073", "Weight": "0.124", "LOS": "0.121"}
 
         for k in exp_smd:
-            smd = t.tableone.loc[k, 'Grouped by MechVent']['SMD (0,1)'][0]
+            smd = t.tableone.loc[k, "Grouped by MechVent"]["SMD (0,1)"][0]
+            assert smd == exp_smd[k]
+
+    def test_compute_standardized_mean_difference_categorical_missing_value_on_separate_row(self, data_pn):
+        """
+        Test that pairwise standardized mean difference is computer correctly
+        for categorical variables.
+
+        # Ref: Introduction to Meta-Analysis. Michael Borenstein,
+        # L. V. Hedges, J. P. T. Higgins and H. R. Rothstein
+        # Wiley (2011). Chapter 4. Effect Sizes Based on Means.
+        """
+
+        t = TableOne(pd.DataFrame([1, 2, 3]), missing_value_on_separate_row=True)
+
+        # test with the physionet data
+        categorical = ["ICU", "MechVent", "death"]
+        strata = "MechVent"
+
+        t = TableOne(
+            data_pn, categorical=categorical, label_suffix=False, groupby=strata, pval=True, htest_name=False, smd=True
+        )
+
+        # consistent with R StdDiff() and R tableone
+        exp_smd = {"ICU": "0.747", "MechVent": "nan", "death": "0.017"}
+
+        for k in exp_smd:
+            smd = t.tableone.loc[k, "Grouped by MechVent"]["SMD (0,1)"][1]
             assert smd == exp_smd[k]
 
     def test_compute_standardized_mean_difference_categorical(self, data_pn):
@@ -980,39 +1233,39 @@ class TestTableOne(object):
         # Wiley (2011). Chapter 4. Effect Sizes Based on Means.
         """
 
-        t = TableOne(pd.DataFrame([1, 2, 3]))
+        t = TableOne(pd.DataFrame([1, 2, 3]), missing_value_on_separate_row=False)
 
         # test with the physionet data
-        categorical = ['ICU', 'MechVent', 'death']
+        categorical = ["ICU", "MechVent", "death"]
         strata = "MechVent"
 
-        t = TableOne(data_pn, categorical=categorical, label_suffix=False,
-                     groupby=strata, pval=True, htest_name=False, smd=True)
+        t = TableOne(
+            data_pn,
+            categorical=categorical,
+            label_suffix=False,
+            groupby=strata,
+            pval=True,
+            htest_name=False,
+            smd=True,
+            missing_value_on_separate_row=False,
+        )
 
         # consistent with R StdDiff() and R tableone
-        exp_smd = {'ICU': '0.747',
-                   'MechVent': 'nan',
-                   'death': '0.017'}
+        exp_smd = {"ICU": "0.747", "MechVent": "nan", "death": "0.017"}
 
         for k in exp_smd:
-            smd = t.tableone.loc[k, 'Grouped by MechVent']['SMD (0,1)'][0]
+            smd = t.tableone.loc[k, "Grouped by MechVent"]["SMD (0,1)"][0]
             assert smd == exp_smd[k]
 
     def test_order_of_order_categorical_columns(self):
         """
         Test that the order of ordered categorical columns is retained.
         """
-        day_cat = pd.Categorical(["mon", "wed", "tue", "thu"],
-                                 categories=["wed", "thu", "mon", "tue"],
-                                 ordered=True)
+        day_cat = pd.Categorical(["mon", "wed", "tue", "thu"], categories=["wed", "thu", "mon", "tue"], ordered=True)
 
-        alph_cat = pd.Categorical(["a", "b", "c", "a"],
-                                  categories=["b", "c", "d", "a"],
-                                  ordered=False)
+        alph_cat = pd.Categorical(["a", "b", "c", "a"], categories=["b", "c", "d", "a"], ordered=False)
 
-        mon_cat = pd.Categorical(["jan", "feb", "mar", "apr"],
-                                 categories=["feb", "jan", "mar", "apr"],
-                                 ordered=True)
+        mon_cat = pd.Categorical(["jan", "feb", "mar", "apr"], categories=["feb", "jan", "mar", "apr"], ordered=True)
 
         data = pd.DataFrame({"A": ["a", "b", "c", "a"]})
         data["day"] = day_cat
@@ -1023,49 +1276,95 @@ class TestTableOne(object):
 
         # if a custom order is not specified, the categorical order
         # specified above should apply
-        t1 = TableOne(data, label_suffix=False)
+        t1 = TableOne(data, label_suffix=False, missing_value_on_separate_row=False)
 
-        t1_expected_order = {'month': ["feb", "jan", "mar", "apr"],
-                             'day': ["wed", "thu", "mon", "tue"]}
+        t1_expected_order = {"month": ["feb", "jan", "mar", "apr"], "day": ["wed", "thu", "mon", "tue"]}
 
         for k in order:
             assert t1._order[k] == t1_expected_order[k]
-            assert (t1.tableone.loc[k].index.to_list() ==
-                    t1_expected_order[k])
+            assert t1.tableone.loc[k].index.to_list() == t1_expected_order[k]
 
         # if a desired order is set, it should override the order
-        t2 = TableOne(data, order=order, label_suffix=False)
+        t2 = TableOne(data, order=order, label_suffix=False, missing_value_on_separate_row=False)
 
-        t2_expected_order = {'month': ["jan", "feb", "mar", "apr"],
-                             'day': ["mon", "tue", "wed", "thu"]}
+        t2_expected_order = {"month": ["jan", "feb", "mar", "apr"], "day": ["mon", "tue", "wed", "thu"]}
 
         for k in order:
             assert t2._order[k] == t2_expected_order[k]
-            assert (t2.tableone.loc[k].index.to_list() ==
-                    t2_expected_order[k])
+            assert t2.tableone.loc[k].index.to_list() == t2_expected_order[k]
+
+    def test_order_of_order_categorical_columns_missing_value_on_separate_row(self):
+        """
+        Test that the order of ordered categorical columns is retained.
+        """
+        day_cat = pd.Categorical(["mon", "wed", "tue", "thu"], categories=["wed", "thu", "mon", "tue"], ordered=True)
+
+        alph_cat = pd.Categorical(["a", "b", "c", "a"], categories=["b", "c", "d", "a"], ordered=False)
+
+        mon_cat = pd.Categorical(["jan", "feb", "mar", "apr"], categories=["feb", "jan", "mar", "apr"], ordered=True)
+
+        data = pd.DataFrame({"A": ["a", "b", "c", "a"]})
+        data["day"] = day_cat
+        data["alph"] = alph_cat
+        data["month"] = mon_cat
+
+        order = {"month": ["jan"], "day": ["mon", "tue", "wed"]}
+
+        # if a custom order is not specified, the categorical order
+        # specified above should apply
+        t1 = TableOne(data, label_suffix=False, missing_value_on_separate_row=True)
+
+        t1_expected_order = {"month": ["feb", "jan", "mar", "apr"], "day": ["wed", "thu", "mon", "tue"]}
+        t1_expected_order_with_missing_count_row = {
+            "month": [" ", "feb", "jan", "mar", "apr"],
+            "day": [" ", "wed", "thu", "mon", "tue"],
+        }
+
+        for k in order:
+            assert t1._order[k] == t1_expected_order[k]
+            assert t1.tableone.loc[k].index.to_list() == t1_expected_order_with_missing_count_row[k]
+
+        # if a desired order is set, it should override the order
+        t2 = TableOne(data, order=order, label_suffix=False, missing_value_on_separate_row=True)
+
+        t2_expected_order = {"month": ["jan", "feb", "mar", "apr"], "day": ["mon", "tue", "wed", "thu"]}
+        t2_expected_order_with_missing_count_row = {
+            "month": [" ", "jan", "feb", "mar", "apr"],
+            "day": [" ", "mon", "tue", "wed", "thu"],
+        }
+
+        for k in order:
+            assert t2._order[k] == t2_expected_order[k]
+            assert t2.tableone.loc[k].index.to_list() == t2_expected_order_with_missing_count_row[k]
 
     def test_min_max_for_nonnormal_variables(self, data_pn):
         """
         Test the min_max argument returns expected results.
         """
         # columns to summarize
-        columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
+        columns = ["Age", "SysABP", "Height", "Weight", "ICU", "death"]
 
         # columns containing categorical variables
-        categorical = ['ICU']
+        categorical = ["ICU"]
 
         # set decimal places for age to 0
         decimals = {"Age": 0}
 
         # non-normal variables
-        nonnormal = ['Age']
+        nonnormal = ["Age"]
 
         # optionally, a categorical variable for stratification
-        groupby = ['death']
+        groupby = ["death"]
 
-        t1 = TableOne(data_pn, columns=columns, categorical=categorical,
-                      groupby=groupby, nonnormal=nonnormal, decimals=decimals,
-                      min_max=['Age'])
+        t1 = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            decimals=decimals,
+            min_max=["Age"],
+        )
 
         k = "Age, median [min,max]"
         group = "Grouped by death"
@@ -1080,49 +1379,111 @@ class TestTableOne(object):
         Test row_percent=False displays n(%) for the column.
         """
         # columns to summarize
-        columns = ['Age', 'SysABP', 'Height', 'MechVent', 'ICU', 'death']
+        columns = ["Age", "SysABP", "Height", "MechVent", "ICU", "death"]
 
         # columns containing categorical variables
-        categorical = ['ICU', 'MechVent']
+        categorical = ["ICU", "MechVent"]
 
         # set decimal places for age to 0
         decimals = {"Age": 0}
 
         # non-normal variables
-        nonnormal = ['Age']
+        nonnormal = ["Age"]
 
         # optionally, a categorical variable for stratification
-        groupby = ['death']
+        groupby = ["death"]
         group = "Grouped by death"
 
         # row_percent = False
-        t1 = TableOne(data_pn, columns=columns,
-                      categorical=categorical, groupby=groupby,
-                      nonnormal=nonnormal, decimals=decimals,
-                      row_percent=False)
+        t1 = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            decimals=decimals,
+            row_percent=False,
+            missing_value_on_separate_row=False,
+        )
 
         row1 = list(t1.tableone.loc["MechVent, n (%)"][group].values[0])
-        row1_expect = [0, '540 (54.0)', '468 (54.2)', '72 (52.9)']
+        row1_expect = [0, "540 (54.0)", "468 (54.2)", "72 (52.9)"]
         assert row1 == row1_expect
 
         row2 = list(t1.tableone.loc["MechVent, n (%)"][group].values[1])
-        row2_expect = ['', '460 (46.0)', '396 (45.8)', '64 (47.1)']
+        row2_expect = ["", "460 (46.0)", "396 (45.8)", "64 (47.1)"]
         assert row2 == row2_expect
 
         row3 = list(t1.tableone.loc["ICU, n (%)"][group].values[0])
-        row3_expect = [0, '162 (16.2)', '137 (15.9)', '25 (18.4)']
+        row3_expect = [0, "162 (16.2)", "137 (15.9)", "25 (18.4)"]
         assert row3 == row3_expect
 
         row4 = list(t1.tableone.loc["ICU, n (%)"][group].values[1])
-        row4_expect = ['', '202 (20.2)', '194 (22.5)', '8 (5.9)']
+        row4_expect = ["", "202 (20.2)", "194 (22.5)", "8 (5.9)"]
         assert row4 == row4_expect
 
         row5 = list(t1.tableone.loc["ICU, n (%)"][group].values[2])
-        row5_expect = ['', '380 (38.0)', '318 (36.8)', '62 (45.6)']
+        row5_expect = ["", "380 (38.0)", "318 (36.8)", "62 (45.6)"]
         assert row5 == row5_expect
 
         row6 = list(t1.tableone.loc["ICU, n (%)"][group].values[3])
-        row6_expect = ['', '256 (25.6)', '215 (24.9)', '41 (30.1)']
+        row6_expect = ["", "256 (25.6)", "215 (24.9)", "41 (30.1)"]
+        assert row6 == row6_expect
+
+    def test_row_percent_false_missing_value_on_separate_row(self, data_pn):
+        """
+        Test row_percent=False displays n(%) for the column.
+        """
+        # columns to summarize
+        columns = ["Age", "SysABP", "Height", "MechVent", "ICU", "death"]
+
+        # columns containing categorical variables
+        categorical = ["ICU", "MechVent"]
+
+        # set decimal places for age to 0
+        decimals = {"Age": 0}
+
+        # non-normal variables
+        nonnormal = ["Age"]
+
+        # optionally, a categorical variable for stratification
+        groupby = ["death"]
+        group = "Grouped by death"
+
+        # row_percent = False
+        t1 = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            decimals=decimals,
+            row_percent=False,
+            missing_value_on_separate_row=True,
+        )
+
+        row1 = list(t1.tableone.loc["MechVent, n (%)"][group].values[1])
+        row1_expect = ["", "540 (54.0)", "468 (54.2)", "72 (52.9)"]
+        assert row1 == row1_expect
+
+        row2 = list(t1.tableone.loc["MechVent, n (%)"][group].values[2])
+        row2_expect = ["", "460 (46.0)", "396 (45.8)", "64 (47.1)"]
+        assert row2 == row2_expect
+
+        row3 = list(t1.tableone.loc["ICU, n (%)"][group].values[1])
+        row3_expect = ["", "162 (16.2)", "137 (15.9)", "25 (18.4)"]
+        assert row3 == row3_expect
+
+        row4 = list(t1.tableone.loc["ICU, n (%)"][group].values[2])
+        row4_expect = ["", "202 (20.2)", "194 (22.5)", "8 (5.9)"]
+        assert row4 == row4_expect
+
+        row5 = list(t1.tableone.loc["ICU, n (%)"][group].values[3])
+        row5_expect = ["", "380 (38.0)", "318 (36.8)", "62 (45.6)"]
+        assert row5 == row5_expect
+
+        row6 = list(t1.tableone.loc["ICU, n (%)"][group].values[4])
+        row6_expect = ["", "256 (25.6)", "215 (24.9)", "41 (30.1)"]
         assert row6 == row6_expect
 
     def test_row_percent_true(self, data_pn):
@@ -1130,49 +1491,168 @@ class TestTableOne(object):
         Test row_percent=True displays n(%) for the row rather than the column.
         """
         # columns to summarize
-        columns = ['Age', 'SysABP', 'Height', 'MechVent', 'ICU', 'death']
+        columns = ["Age", "SysABP", "Height", "MechVent", "ICU", "death"]
 
         # columns containing categorical variables
-        categorical = ['ICU', 'MechVent']
+        categorical = ["ICU", "MechVent"]
 
         # set decimal places for age to 0
         decimals = {"Age": 0}
 
         # non-normal variables
-        nonnormal = ['Age']
+        nonnormal = ["Age"]
 
         # optionally, a categorical variable for stratification
-        groupby = ['death']
+        groupby = ["death"]
         group = "Grouped by death"
 
         # row_percent = True
-        t2 = TableOne(data_pn, columns=columns,
-                      categorical=categorical, groupby=groupby,
-                      nonnormal=nonnormal, decimals=decimals,
-                      row_percent=True)
+        t2 = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            decimals=decimals,
+            row_percent=True,
+            missing_value_on_separate_row=False,
+        )
 
         row1 = list(t2.tableone.loc["MechVent, n (%)"][group].values[0])
-        row1_expect = [0, '540 (100.0)', '468 (86.7)', '72 (13.3)']
+        row1_expect = [0, "540 (100.0)", "468 (86.7)", "72 (13.3)"]
         assert row1 == row1_expect
 
         row2 = list(t2.tableone.loc["MechVent, n (%)"][group].values[1])
-        row2_expect = ['', '460 (100.0)', '396 (86.1)', '64 (13.9)']
+        row2_expect = ["", "460 (100.0)", "396 (86.1)", "64 (13.9)"]
         assert row2 == row2_expect
 
         row3 = list(t2.tableone.loc["ICU, n (%)"][group].values[0])
-        row3_expect = [0, '162 (100.0)', '137 (84.6)', '25 (15.4)']
+        row3_expect = [0, "162 (100.0)", "137 (84.6)", "25 (15.4)"]
         assert row3 == row3_expect
 
         row4 = list(t2.tableone.loc["ICU, n (%)"][group].values[1])
-        row4_expect = ['', '202 (100.0)', '194 (96.0)', '8 (4.0)']
+        row4_expect = ["", "202 (100.0)", "194 (96.0)", "8 (4.0)"]
         assert row4 == row4_expect
 
         row5 = list(t2.tableone.loc["ICU, n (%)"][group].values[2])
-        row5_expect = ['', '380 (100.0)', '318 (83.7)', '62 (16.3)']
+        row5_expect = ["", "380 (100.0)", "318 (83.7)", "62 (16.3)"]
         assert row5 == row5_expect
 
         row6 = list(t2.tableone.loc["ICU, n (%)"][group].values[3])
-        row6_expect = ['', '256 (100.0)', '215 (84.0)', '41 (16.0)']
+        row6_expect = ["", "256 (100.0)", "215 (84.0)", "41 (16.0)"]
+        assert row6 == row6_expect
+
+    def test_row_percent_true_missing_value_on_separate_row(self, data_pn):
+        """
+        Test row_percent=True displays n(%) for the row rather than the column.
+        """
+        # columns to summarize
+        columns = ["Age", "SysABP", "Height", "MechVent", "ICU", "death"]
+
+        # columns containing categorical variables
+        categorical = ["ICU", "MechVent"]
+
+        # set decimal places for age to 0
+        decimals = {"Age": 0}
+
+        # non-normal variables
+        nonnormal = ["Age"]
+
+        # optionally, a categorical variable for stratification
+        groupby = ["death"]
+        group = "Grouped by death"
+
+        # row_percent = True
+        t2 = TableOne(
+            data_pn,
+            columns=columns,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            decimals=decimals,
+            row_percent=True,
+            missing_value_on_separate_row=True,
+        )
+
+        row1 = list(t2.tableone.loc["MechVent, n (%)"][group].values[1])
+        row1_expect = ["", "540 (100.0)", "468 (86.7)", "72 (13.3)"]
+        assert row1 == row1_expect
+
+        row2 = list(t2.tableone.loc["MechVent, n (%)"][group].values[2])
+        row2_expect = ["", "460 (100.0)", "396 (86.1)", "64 (13.9)"]
+        assert row2 == row2_expect
+
+        row3 = list(t2.tableone.loc["ICU, n (%)"][group].values[1])
+        row3_expect = ["", "162 (100.0)", "137 (84.6)", "25 (15.4)"]
+        assert row3 == row3_expect
+
+        row4 = list(t2.tableone.loc["ICU, n (%)"][group].values[2])
+        row4_expect = ["", "202 (100.0)", "194 (96.0)", "8 (4.0)"]
+        assert row4 == row4_expect
+
+        row5 = list(t2.tableone.loc["ICU, n (%)"][group].values[3])
+        row5_expect = ["", "380 (100.0)", "318 (83.7)", "62 (16.3)"]
+        assert row5 == row5_expect
+
+        row6 = list(t2.tableone.loc["ICU, n (%)"][group].values[4])
+        row6_expect = ["", "256 (100.0)", "215 (84.0)", "41 (16.0)"]
+        assert row6 == row6_expect
+
+    def test_row_percent_true_and_overall_false_dedicated_missing_row_mode(self, data_pn):
+        """
+        Test row_percent=True displays n(%) for the row rather than the column.
+        """
+        # columns to summarize
+        columns = ["Age", "SysABP", "Height", "MechVent", "ICU", "death"]
+
+        # columns containing categorical variables
+        categorical = ["ICU", "MechVent"]
+
+        # set decimal places for age to 0
+        decimals = {"Age": 0}
+
+        # non-normal variables
+        nonnormal = ["Age"]
+
+        # optionally, a categorical variable for stratification
+        groupby = ["death"]
+        group = "Grouped by death"
+
+        # row_percent = True
+        t1 = TableOne(
+            data_pn,
+            columns=columns,
+            overall=False,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            decimals=decimals,
+            row_percent=True,
+            missing_value_on_separate_row=True,
+        )
+
+        row1 = list(t1.tableone.loc["MechVent, n (%)"][group].values[1])
+        row1_expect = ["", "468 (86.7)", "72 (13.3)"]
+        assert row1 == row1_expect
+
+        row2 = list(t1.tableone.loc["MechVent, n (%)"][group].values[2])
+        row2_expect = ["", "396 (86.1)", "64 (13.9)"]
+        assert row2 == row2_expect
+
+        row3 = list(t1.tableone.loc["ICU, n (%)"][group].values[1])
+        row3_expect = ["", "137 (84.6)", "25 (15.4)"]
+        assert row3 == row3_expect
+
+        row4 = list(t1.tableone.loc["ICU, n (%)"][group].values[2])
+        row4_expect = ["", "194 (96.0)", "8 (4.0)"]
+        assert row4 == row4_expect
+
+        row5 = list(t1.tableone.loc["ICU, n (%)"][group].values[3])
+        row5_expect = ["", "318 (83.7)", "62 (16.3)"]
+        assert row5 == row5_expect
+
+        row6 = list(t1.tableone.loc["ICU, n (%)"][group].values[4])
+        row6_expect = ["", "215 (84.0)", "41 (16.0)"]
         assert row6 == row6_expect
 
     def test_row_percent_true_and_overall_false(self, data_pn):
@@ -1180,47 +1660,54 @@ class TestTableOne(object):
         Test row_percent=True displays n(%) for the row rather than the column.
         """
         # columns to summarize
-        columns = ['Age', 'SysABP', 'Height', 'MechVent', 'ICU', 'death']
+        columns = ["Age", "SysABP", "Height", "MechVent", "ICU", "death"]
 
         # columns containing categorical variables
-        categorical = ['ICU', 'MechVent']
+        categorical = ["ICU", "MechVent"]
 
         # set decimal places for age to 0
         decimals = {"Age": 0}
 
         # non-normal variables
-        nonnormal = ['Age']
+        nonnormal = ["Age"]
 
         # optionally, a categorical variable for stratification
-        groupby = ['death']
+        groupby = ["death"]
         group = "Grouped by death"
 
         # row_percent = True
-        t1 = TableOne(data_pn, columns=columns, overall=False,
-                      categorical=categorical, groupby=groupby,
-                      nonnormal=nonnormal, decimals=decimals,
-                      row_percent=True)
+        t1 = TableOne(
+            data_pn,
+            columns=columns,
+            overall=False,
+            categorical=categorical,
+            groupby=groupby,
+            nonnormal=nonnormal,
+            decimals=decimals,
+            row_percent=True,
+            missing_value_on_separate_row=False,
+        )
 
         row1 = list(t1.tableone.loc["MechVent, n (%)"][group].values[0])
-        row1_expect = [0, '468 (86.7)', '72 (13.3)']
+        row1_expect = [0, "468 (86.7)", "72 (13.3)"]
         assert row1 == row1_expect
 
         row2 = list(t1.tableone.loc["MechVent, n (%)"][group].values[1])
-        row2_expect = ['', '396 (86.1)', '64 (13.9)']
+        row2_expect = ["", "396 (86.1)", "64 (13.9)"]
         assert row2 == row2_expect
 
         row3 = list(t1.tableone.loc["ICU, n (%)"][group].values[0])
-        row3_expect = [0, '137 (84.6)', '25 (15.4)']
+        row3_expect = [0, "137 (84.6)", "25 (15.4)"]
         assert row3 == row3_expect
 
         row4 = list(t1.tableone.loc["ICU, n (%)"][group].values[1])
-        row4_expect = ['', '194 (96.0)', '8 (4.0)']
+        row4_expect = ["", "194 (96.0)", "8 (4.0)"]
         assert row4 == row4_expect
 
         row5 = list(t1.tableone.loc["ICU, n (%)"][group].values[2])
-        row5_expect = ['', '318 (83.7)', '62 (16.3)']
+        row5_expect = ["", "318 (83.7)", "62 (16.3)"]
         assert row5 == row5_expect
 
         row6 = list(t1.tableone.loc["ICU, n (%)"][group].values[3])
-        row6_expect = ['', '215 (84.0)', '41 (16.0)']
+        row6_expect = ["", "215 (84.0)", "41 (16.0)"]
         assert row6 == row6_expect


### PR DESCRIPTION
Original implementation had the missing value count on the same line as the first categorical value, which made reading the table a bit more confusing.

I started out by making the missing value count line showing up on its own line, but ended up moving other column values as P-Value, SMD because those are pretty much the same in terms of readability.

Since I'm not a pandas guru, I hacked whatever I could to get to the results I wanted. I copied over many of the existing unit tests into new ones and adjusted them to make sure old behaviors are kept in tact. As far as I can tell, turning off the newly added parameter `missing_value_on_separate_row` behaves exactly the same as before.

<img width="835" alt="Screenshot 2024-01-27 at 12 12 16 PM" src="https://github.com/cipherome/tableone-ci/assets/52687419/173170af-fd15-472e-a165-994f4dc6f291">
with the `missing_value_on_separate_row` set to `True`


<img width="900" alt="Screenshot 2024-01-27 at 12 19 06 PM" src="https://github.com/cipherome/tableone-ci/assets/52687419/603c68cc-7df6-41b7-8b5a-7a17ef748c17">
with the `missing_value_on_separate_row` set to `False`


** many of the changes are due to the code formatting my default black config made

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206408400393813